### PR TITLE
fix: Detect YouTube 'not a bot' as cookie/auth error (issue #175)

### DIFF
--- a/COMMANDS/cookies_cmd.py
+++ b/COMMANDS/cookies_cmd.py
@@ -1914,7 +1914,7 @@ def is_youtube_cookie_error(error_message: str) -> bool:
         'sign in', 'login required', 'age restricted', 'cookies', 
         'authentication', 'format not found', 'no formats found', 'unable to extract', 
         'http error 403', 'http error 401', 'forbidden', 'unauthorized', 'access denied',
-        'subscription required'
+        'subscription required', "not a bot", "confirm you're not a bot", "confirm you are not a bot"
     ]
     
     return any(keyword in error_lower for keyword in cookie_related_keywords)


### PR DESCRIPTION
## Summary
- Расширяет `is_youtube_cookie_error()` ключевыми словами для ошибки YouTube "confirm you're not a bot".
- Это включает существующий механизм ретраев с куками там, где раньше ошибка могла не классифицироваться как cookie/auth.

Fixes #175

## Test plan
- `python3 -m py_compile COMMANDS/cookies_cmd.py`

Made with [Cursor](https://cursor.com)