### PR TITLE
fix: Instagram rate-limit/login triggers cookie fallback (issue #177)

### DIFF
--- a/DOWN_AND_UP/down_and_up.py
+++ b/DOWN_AND_UP/down_and_up.py
@@ -2294,7 +2294,7 @@ def down_and_up(app, message, url, playlist_name, video_count, video_start_with,
                     
                     # Проверяем, связана ли ошибка с куки
                     error_str = error_message.lower()
-                    if any(keyword in error_str for keyword in ['cookie', 'auth', 'login', 'sign in', '403', '401', 'forbidden', 'unauthorized']):
+                    if any(keyword in error_str for keyword in ['cookie', 'auth', 'login', 'sign in', '403', '401', 'forbidden', 'unauthorized', 'rate-limit', 'rate limit', 'login required', 'requested content is not available']):
                         logger.info(f"Error appears to be cookie-related for {url}, trying cookie fallback")
                         
                         # Пробуем перебор куки с новой системой


### PR DESCRIPTION
## Summary
- Добавляет Instagram-типичные формулировки (`rate-limit reached`, `login required`, `requested content is not available`) в эвристику non‑YouTube cookie fallback.

Fixes #177

## Test plan
- `python3 -m py_compile DOWN_AND_UP/down_and_up.py`

Made with [Cursor](https://cursor.com)