### PR TITLE
fix: Guard against missing/empty files before Telegram send (issue #179)

### DIFF
--- a/DOWN_AND_UP/sender.py
+++ b/DOWN_AND_UP/sender.py
@@ -479,6 +479,8 @@ def send_videos(
         def _try_send_video(caption_text: str):
             messages = safe_get_messages(user_id)
             nonlocal was_paid
+            if not os.path.exists(video_abs_path) or os.path.getsize(video_abs_path) <= 0:
+                raise FileNotFoundError(f"Video file not found or empty: {video_abs_path}")
             # Для бесплатных сообщений — внешний превью без паддинга; для платных — обложка 320x320
             local_thumb_free = None
             try:
@@ -626,6 +628,8 @@ def send_videos(
         def _fallback_send_document(caption_text: str):
             messages = safe_get_messages(user_id)
             nonlocal was_paid
+            if not os.path.exists(video_abs_path) or os.path.getsize(video_abs_path) <= 0:
+                raise FileNotFoundError(f"Video file not found or empty: {video_abs_path}")
             # Для бесплатных документов — внешний превью без паддинга
             local_thumb = _gen_free_cover(video_abs_path) or thumb_file_path
             try:


### PR DESCRIPTION
## Summary
- Перед `send_video`/`send_document` проверяем, что файл существует и не пустой.
- Это даёт более предсказуемую ошибку вместо "Failed to decode" при гонках/очистке файлов.

Fixes #179

## Test plan
- `python3 -m py_compile DOWN_AND_UP/sender.py`

Made with [Cursor](https://cursor.com)