### PR TITLE
fix: Clear user messages for geo/copyright restrictions (issue #182)

### DIFF
--- a/DOWN_AND_UP/down_and_up.py
+++ b/DOWN_AND_UP/down_and_up.py
@@ -2746,6 +2746,25 @@ def down_and_up(app, message, url, playlist_name, video_count, video_start_with,
                         )
                         send_error_to_user(message, format_error_message)
                         error_message_sent = True
+                    elif ("not available in your country" in error_message.lower()) or ("has not made this video available in your country" in error_message.lower()):
+                        geo_error_message = (
+                            "🌍 **Region restriction**\n"
+                            "This video is not available in your country.\n\n"
+                            "**What you can try:**\n"
+                            "• Enable proxy and retry (/proxy)\n"
+                            "• If you already use proxy: switch proxy country\n"
+                            "• Try a different mirror/reupload (if any)"
+                        )
+                        send_error_to_user(message, geo_error_message)
+                        error_message_sent = True
+                    elif ("blocked it on copyright grounds" in error_message.lower()) or ("copyright grounds" in error_message.lower()):
+                        copyright_message = (
+                            "⛔ **Copyright restriction**\n"
+                            "The uploader/rightsholder blocked this video on copyright grounds.\n\n"
+                            "This is not a technical issue — the bot can't bypass it."
+                        )
+                        send_error_to_user(message, copyright_message)
+                        error_message_sent = True
                 
                 with playlist_errors_lock:
                     error_key = f"{user_id}_{playlist_name}"


### PR DESCRIPTION
## Summary
- Добавляет явные сообщения пользователю для YouTube geo‑restriction и copyright‑block.
- Даёт подсказки про включение/смену прокси.

Fixes #182

## Test plan
- `python3 -m py_compile DOWN_AND_UP/down_and_up.py`

Made with [Cursor](https://cursor.com)