### PR TITLE
fix(docker): resolve dashboard TemplateResponse crash and warp health…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,6 +165,7 @@ env
 delete_redacted.sh
 tg-ytdlp-NEW.code-workspace
 *.code-workspace
+tg-ytdlp-bot.code-workspace
 
 # Kilo agent skill/command files (local tooling, not project code)
 .kilo/command/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,12 +85,14 @@ services:
     networks:
       - warp-net
     healthcheck:
-      # Проверяем, что WireGuard работает и DNS разрешается
-      test: ["CMD-SHELL", "wg show wgcf >/dev/null 2>&1 && (getent hosts google.com >/dev/null 2>&1 || curl -s --max-time 5 https://www.google.com >/dev/null 2>&1)"]
+      # WireGuard interface must be up; DNS reachability is best-effort
+      # (google.com may fail on geo-blocked/DNS-restricted hosts without
+      # meaning the tunnel itself is broken, so we don't block startup on it)
+      test: ["CMD-SHELL", "wg show wgcf >/dev/null 2>&1"]
       interval: 10s
       timeout: 5s
-      retries: 5
-      start_period: 30s
+      retries: 10
+      start_period: 40s
 
 networks:
   warp-net:

--- a/web/dashboard_app.py
+++ b/web/dashboard_app.py
@@ -74,7 +74,7 @@ app.add_middleware(AuthMiddleware)
 
 @app.get("/login", response_class=HTMLResponse)
 async def login_page(request: Request):
-    return templates.TemplateResponse("login.html", {"request": request})
+    return templates.TemplateResponse(request, "login.html")
 
 
 class LoginRequest(BaseModel):
@@ -128,9 +128,9 @@ async def api_logout(request: Request):
 @app.get("/", response_class=HTMLResponse)
 async def dashboard(request: Request):
     return templates.TemplateResponse(
+        request,
         "dashboard.html",
         {
-            "request": request,
             "title": "Статистика бота",
             "config": {
                 "STATS_ACTIVE_TIMEOUT": getattr(Config, "STATS_ACTIVE_TIMEOUT", 900),
@@ -149,7 +149,7 @@ async def api_active_users(
 
 @app.get("/api/top-downloaders")
 async def api_top_downloaders(
-    period: str = Query(default="today", regex="^(today|week|month|all)$"),
+    period: str = Query(default="today", pattern="^(today|week|month|all)$"),
     limit: int = 10,
 ):
     return stats_service.fetch_top_downloaders(period=period, limit=limit)
@@ -197,7 +197,7 @@ async def api_playlist_users(limit: int = 10):
 
 @app.get("/api/top-multi-url-users")
 async def api_multi_url_users(
-    period: str = Query(default="today", regex="^(today|week|month|all)$"),
+    period: str = Query(default="today", pattern="^(today|week|month|all)$"),
     limit: int = 10,
 ):
     return stats_service.fetch_top_multi_url_users(period=period, limit=limit)
@@ -225,7 +225,7 @@ async def api_channel_events(hours: int = 48, limit: int = 100):
 
 @app.get("/api/suspicious-users")
 async def api_suspicious_users(
-    period: str = Query(default="today", regex="^(today|week|month|all)$"),
+    period: str = Query(default="today", pattern="^(today|week|month|all)$"),
     limit: int = 20,
 ):
     return stats_service.fetch_suspicious_users(period=period, limit=limit)
@@ -234,7 +234,7 @@ async def api_suspicious_users(
 @app.get("/api/user-history")
 async def api_user_history(
     user_id: int = Query(..., gt=0),
-    period: str = Query(default="all", regex="^(today|week|month|all)$"),
+    period: str = Query(default="all", pattern="^(today|week|month|all)$"),
     limit: int = Query(default=100, le=1000),
 ):
     return stats_service.fetch_user_history(user_id, period, limit)


### PR DESCRIPTION
…check blocking stack

- Update Query regex= to pattern= (FastAPI/Pydantic v2 deprecation)
- Loosen warp healthcheck to WireGuard interface only (DNS geo-blocks no longer permanently block bot/bgutil/dashboard startup)
- gitignore: add workspace file