### PR TITLE
fix(i18n): change DOWNLOAD_STARTED_MSG from 'download started' to 'pl…

### DIFF
--- a/CONFIG/LANGUAGES/messages_AR.py
+++ b/CONFIG/LANGUAGES/messages_AR.py
@@ -2149,7 +2149,7 @@ class Messages(object):
     GALLERY_DL_UNKNOWN_ERROR_MSG = "خطأ غير معروف"
     
     # Download started message (used in both audio and video downloads)
-    DOWNLOAD_STARTED_MSG = "<b>▶️ بدأ التحميل</b>"
+    DOWNLOAD_STARTED_MSG = "<b>⏳ يرجى الانتظار...</b>"
     
     # Split command constants
     SPLIT_CLOSE_BUTTON_MSG = "🔚إغلاق"

--- a/CONFIG/LANGUAGES/messages_BN.py
+++ b/CONFIG/LANGUAGES/messages_BN.py
@@ -2143,7 +2143,7 @@ class Messages(object):
     GALLERY_DL_UNKNOWN_ERROR_MSG = "অজানা ত্রুটি"
     
     # Download started message (used in both audio and video downloads)
-    DOWNLOAD_STARTED_MSG = "<b>▶️ ডাউনলোড শুরু হয়েছে</b>"
+    DOWNLOAD_STARTED_MSG = "<b>⏳ অনুগ্রহ করে অপেক্ষা করুন...</b>"
     
     # Split command constants
     SPLIT_CLOSE_BUTTON_MSG = "🔚বন্ধ করুন"

--- a/CONFIG/LANGUAGES/messages_DE.py
+++ b/CONFIG/LANGUAGES/messages_DE.py
@@ -2144,7 +2144,7 @@ Mehr erfahren: /playlist"""
     GALLERY_DL_UNKNOWN_ERROR_MSG = "Unbekannter Fehler"
     
     # Download started message (used in both audio and video downloads)
-    DOWNLOAD_STARTED_MSG = "<b>▶️ Download gestartet</b>"
+    DOWNLOAD_STARTED_MSG = "<b>⏳ Bitte warten...</b>"
     
     # Split command constants
     SPLIT_CLOSE_BUTTON_MSG = "🔚Schließen"

--- a/CONFIG/LANGUAGES/messages_EN.py
+++ b/CONFIG/LANGUAGES/messages_EN.py
@@ -2143,7 +2143,7 @@ Learn more: /playlist"""
     GALLERY_DL_UNKNOWN_ERROR_MSG = "Unknown Error"
     
     # Download started message (used in both audio and video downloads)
-    DOWNLOAD_STARTED_MSG = "<b>▶️ Download started</b>"
+    DOWNLOAD_STARTED_MSG = "<b>⏳ Please wait...</b>"
     
     # Split command constants
     SPLIT_CLOSE_BUTTON_MSG = "🔚Close"

--- a/CONFIG/LANGUAGES/messages_ES.py
+++ b/CONFIG/LANGUAGES/messages_ES.py
@@ -2143,7 +2143,7 @@ Más información: /playlist"""
     GALLERY_DL_UNKNOWN_ERROR_MSG = "Error Desconocido"
     
     # Download started message (used in both audio and video downloads)
-    DOWNLOAD_STARTED_MSG = "<b>▶️ Descarga iniciada</b>"
+    DOWNLOAD_STARTED_MSG = "<b>⏳ Por favor espere...</b>"
     
     # Split command constants
     SPLIT_CLOSE_BUTTON_MSG = "🔚Cerrar"

--- a/CONFIG/LANGUAGES/messages_FA.py
+++ b/CONFIG/LANGUAGES/messages_FA.py
@@ -2143,7 +2143,7 @@ class Messages(object):
     GALLERY_DL_UNKNOWN_ERROR_MSG = "خطای ناشناخته"
     
     # Download started message (used in both audio and video downloads)
-    DOWNLOAD_STARTED_MSG = "<b>▶️ دانلود شروع شد</b>"
+    DOWNLOAD_STARTED_MSG = "<b>⏳ لطفاً صبر کنید...</b>"
     
     # Split command constants
     SPLIT_CLOSE_BUTTON_MSG = "🔚بستن"

--- a/CONFIG/LANGUAGES/messages_FR.py
+++ b/CONFIG/LANGUAGES/messages_FR.py
@@ -2144,7 +2144,7 @@ En savoir plus : /playlist"""
     GALLERY_DL_UNKNOWN_ERROR_MSG = "Erreur Inconnue"
     
     # Download started message (used in both audio and video downloads)
-    DOWNLOAD_STARTED_MSG = "<b>▶️ Téléchargement démarré</b>"
+    DOWNLOAD_STARTED_MSG = "<b>⏳ Veuillez patienter...</b>"
     
     # Split command constants
     SPLIT_CLOSE_BUTTON_MSG = "🔚Fermer"

--- a/CONFIG/LANGUAGES/messages_HA.py
+++ b/CONFIG/LANGUAGES/messages_HA.py
@@ -2144,7 +2144,7 @@ Koyi ƙari: /playlist"""
     GALLERY_DL_UNKNOWN_ERROR_MSG = "Kuskuren da ba a sani ba"
     
     # Download started message (used in both audio and video downloads)
-    DOWNLOAD_STARTED_MSG = "<b>▶️ An fara saukewa</b>"
+    DOWNLOAD_STARTED_MSG = "<b>⏳ Da fatan za a jira...</b>"
     
     # Split command constants
     SPLIT_CLOSE_BUTTON_MSG = "🔚Rufe"

--- a/CONFIG/LANGUAGES/messages_ID.py
+++ b/CONFIG/LANGUAGES/messages_ID.py
@@ -2143,7 +2143,7 @@ Pelajari lebih lanjut: /playlist"""
     GALLERY_DL_UNKNOWN_ERROR_MSG = "Error Tidak Dikenal"
     
     # Download started message (used in both audio and video downloads)
-    DOWNLOAD_STARTED_MSG = "<b>▶️ Unduhan dimulai</b>"
+    DOWNLOAD_STARTED_MSG = "<b>⏳ Mohon tunggu...</b>"
     
     # Split command constants
     SPLIT_CLOSE_BUTTON_MSG = "🔚Tutup"

--- a/CONFIG/LANGUAGES/messages_IN.py
+++ b/CONFIG/LANGUAGES/messages_IN.py
@@ -2142,7 +2142,7 @@ class Messages(object):
     GALLERY_DL_UNKNOWN_ERROR_MSG = "अज्ञात त्रुटि"
     
     # Download started message (used in both audio and video downloads)
-    DOWNLOAD_STARTED_MSG = "<b>▶️ डाउनलोड शुरू हुआ</b>"
+    DOWNLOAD_STARTED_MSG = "<b>⏳ कृपया प्रतीक्षा करें...</b>"
     
     # Split command constants
     SPLIT_CLOSE_BUTTON_MSG = "🔚बंद करें"

--- a/CONFIG/LANGUAGES/messages_IT.py
+++ b/CONFIG/LANGUAGES/messages_IT.py
@@ -2143,7 +2143,7 @@ Scopri di più: /playlist"""
     GALLERY_DL_UNKNOWN_ERROR_MSG = "Errore sconosciuto"
     
     # Download started message (used in both audio and video downloads)
-    DOWNLOAD_STARTED_MSG = "<b>♥️ Download avviato</b>"
+    DOWNLOAD_STARTED_MSG = "<b>⏳ Attendere...</b>"
     
     # Split command constants
     SPLIT_CLOSE_BUTTON_MSG = "🔚Chiudi"

--- a/CONFIG/LANGUAGES/messages_JA.py
+++ b/CONFIG/LANGUAGES/messages_JA.py
@@ -2143,7 +2143,7 @@ class Messages(object):
     GALLERY_DL_UNKNOWN_ERROR_MSG = "不明なエラー"
     
     # Download started message (used in both audio and video downloads)
-    DOWNLOAD_STARTED_MSG = "<b>▶️ ダウンロードが開始されました</b>"
+    DOWNLOAD_STARTED_MSG = "<b>⏳ お待ちください...</b>"
     
     # Split command constants
     SPLIT_CLOSE_BUTTON_MSG = "🔚閉じる"

--- a/CONFIG/LANGUAGES/messages_KK.py
+++ b/CONFIG/LANGUAGES/messages_KK.py
@@ -2144,7 +2144,7 @@ class Messages(object):
     GALLERY_DL_UNKNOWN_ERROR_MSG = "Белгісіз қате"
     
     # Download started message (used in both audio and video downloads)
-    DOWNLOAD_STARTED_MSG = "<b>▶️ Жүктеп алу басталды</b>"
+    DOWNLOAD_STARTED_MSG = "<b>⏳ Күте тұрыңыз...</b>"
     
     # Split command constants
     SPLIT_CLOSE_BUTTON_MSG = "🔚Жабу"

--- a/CONFIG/LANGUAGES/messages_KO.py
+++ b/CONFIG/LANGUAGES/messages_KO.py
@@ -2143,7 +2143,7 @@ class Messages(object):
     GALLERY_DL_UNKNOWN_ERROR_MSG = "알 수 없는 오류"
     
     # Download started message (used in both audio and video downloads)
-    DOWNLOAD_STARTED_MSG = "<b>▶️ 다운로드 시작됨</b>"
+    DOWNLOAD_STARTED_MSG = "<b>⏳ 잠시만 기다려 주세요...</b>"
     
     # Split command constants
     SPLIT_CLOSE_BUTTON_MSG = "🔚Close"

--- a/CONFIG/LANGUAGES/messages_PL.py
+++ b/CONFIG/LANGUAGES/messages_PL.py
@@ -2074,7 +2074,7 @@ Dowiedz się więcej: /playlist"""
     GALLERY_DL_UNKNOWN_ERROR_MSG = "Nieznany błąd"
     
     # Download started message (used in both audio and video downloads)
-    DOWNLOAD_STARTED_MSG = "<b>▶️ Pobieranie rozpoczęte</b>"
+    DOWNLOAD_STARTED_MSG = "<b>⏳ Proszę czekać...</b>"
     
     # Split command constants
     SPLIT_CLOSE_BUTTON_MSG = "🔚Zamknij"

--- a/CONFIG/LANGUAGES/messages_PT.py
+++ b/CONFIG/LANGUAGES/messages_PT.py
@@ -2143,7 +2143,7 @@ Saiba mais: /playlist"""
     GALLERY_DL_UNKNOWN_ERROR_MSG = "Erro Desconhecido"
     
     # Download started message (used in both audio and video downloads)
-    DOWNLOAD_STARTED_MSG = "<b>▶️ Download iniciado</b>"
+    DOWNLOAD_STARTED_MSG = "<b>⏳ Aguarde...</b>"
     
     # Split command constants
     SPLIT_CLOSE_BUTTON_MSG = "🔚Fechar"

--- a/CONFIG/LANGUAGES/messages_RU.py
+++ b/CONFIG/LANGUAGES/messages_RU.py
@@ -2145,7 +2145,7 @@ class Messages(object):
     GALLERY_DL_UNKNOWN_ERROR_MSG = "Неизвестная ошибка"
     
     # Download started message (used in both audio and video downloads)
-    DOWNLOAD_STARTED_MSG = "<b>▶️ Скачивание началось</b>"
+    DOWNLOAD_STARTED_MSG = "<b>⏳ Ожидайте...</b>"
     
     # Split command constants
     SPLIT_CLOSE_BUTTON_MSG = "🔚Закрыть"

--- a/CONFIG/LANGUAGES/messages_TH.py
+++ b/CONFIG/LANGUAGES/messages_TH.py
@@ -2143,7 +2143,7 @@ class Messages(object):
     GALLERY_DL_UNKNOWN_ERROR_MSG = "ข้อผิดพลาดที่ไม่ทราบสาเหตุ"
     
     # Download started message (used in both audio and video downloads)
-    DOWNLOAD_STARTED_MSG = "<b>▶️ เริ่มการดาวน์โหลด</b>"
+    DOWNLOAD_STARTED_MSG = "<b>⏳ กรุณารอ...</b>"
     
     # Split command constants
     SPLIT_CLOSE_BUTTON_MSG = "🔚ปิด"

--- a/CONFIG/LANGUAGES/messages_TL.py
+++ b/CONFIG/LANGUAGES/messages_TL.py
@@ -2144,7 +2144,7 @@ Matuto pa: /playlist"""
     GALLERY_DL_UNKNOWN_ERROR_MSG = "Hindi Alam na Error"
     
     # Download started message (used in both audio and video downloads)
-    DOWNLOAD_STARTED_MSG = "<b>▶️ Nagsimula ang pag-download</b>"
+    DOWNLOAD_STARTED_MSG = "<b>⏳ Mangyaring maghintay...</b>"
     
     # Split command constants
     SPLIT_CLOSE_BUTTON_MSG = "🔚Isara"

--- a/CONFIG/LANGUAGES/messages_TR.py
+++ b/CONFIG/LANGUAGES/messages_TR.py
@@ -2143,7 +2143,7 @@ Daha fazla bilgi: /playlist"""
     GALLERY_DL_UNKNOWN_ERROR_MSG = "Bilinmeyen Hata"
     
     # Download started message (used in both audio and video downloads)
-    DOWNLOAD_STARTED_MSG = "<b>▶️ İndirme başlatıldı</b>"
+    DOWNLOAD_STARTED_MSG = "<b>⏳ Lütfen bekleyin...</b>"
     
     # Split command constants
     SPLIT_CLOSE_BUTTON_MSG = "🔚Kapat"

--- a/CONFIG/LANGUAGES/messages_UK.py
+++ b/CONFIG/LANGUAGES/messages_UK.py
@@ -2143,7 +2143,7 @@ class Messages(object):
     GALLERY_DL_UNKNOWN_ERROR_MSG = "Невідома помилка"
     
     # Download started message (used in both audio and video downloads)
-    DOWNLOAD_STARTED_MSG = "<b>▶️ Завантаження розпочато</b>"
+    DOWNLOAD_STARTED_MSG = "<b>⏳ Зачекайте...</b>"
     
     # Split command constants
     SPLIT_CLOSE_BUTTON_MSG = "🔚Закрити"

--- a/CONFIG/LANGUAGES/messages_UR.py
+++ b/CONFIG/LANGUAGES/messages_UR.py
@@ -2144,7 +2144,7 @@ Use:
     GALLERY_DL_UNKNOWN_ERROR_MSG = "نامعلوم خرابی"
     
     # Download started message (used in both audio and video downloads)
-    DOWNLOAD_STARTED_MSG = "<b>▶️ ڈاؤن لوڈ شروع ہو گیا</b>"
+    DOWNLOAD_STARTED_MSG = "<b>⏳ براہ کرم انتظار کریں...</b>"
     
     # Split command constants
     SPLIT_CLOSE_BUTTON_MSG = "🔚بند کریں"

--- a/CONFIG/LANGUAGES/messages_UZ.py
+++ b/CONFIG/LANGUAGES/messages_UZ.py
@@ -2143,7 +2143,7 @@ Ko'proq ma'lumot: /playlist"""
     GALLERY_DL_UNKNOWN_ERROR_MSG = "Noma'lum xatolik"
     
     # Download started message (used in both audio and video downloads)
-    DOWNLOAD_STARTED_MSG = "<b>▶️ Yuklab olish boshlandi</b>"
+    DOWNLOAD_STARTED_MSG = "<b>⏳ Iltimos kuting...</b>"
     
     # Split command constants
     SPLIT_CLOSE_BUTTON_MSG = "🔚Yopish"

--- a/CONFIG/LANGUAGES/messages_VI.py
+++ b/CONFIG/LANGUAGES/messages_VI.py
@@ -2143,7 +2143,7 @@ Tìm hiểu thêm: /playlist"""
     GALLERY_DL_UNKNOWN_ERROR_MSG = "Lỗi Không Xác Định"
     
     # Download started message (used in both audio and video downloads)
-    DOWNLOAD_STARTED_MSG = "<b>▶️ Tải xuống đã bắt đầu</b>"
+    DOWNLOAD_STARTED_MSG = "<b>⏳ Vui lòng đợi...</b>"
     
     # Split command constants
     SPLIT_CLOSE_BUTTON_MSG = "🔚Đóng"

--- a/CONFIG/LANGUAGES/messages_ZH.py
+++ b/CONFIG/LANGUAGES/messages_ZH.py
@@ -2143,7 +2143,7 @@ class Messages(object):
     GALLERY_DL_UNKNOWN_ERROR_MSG = "未知错误"
     
     # Download started message (used in both audio and video downloads)
-    DOWNLOAD_STARTED_MSG = "<b>▶️ 下载已开始</b>"
+    DOWNLOAD_STARTED_MSG = "<b>⏳ 请稍候...</b>"
     
     # Split command constants
     SPLIT_CLOSE_BUTTON_MSG = "🔚关闭"


### PR DESCRIPTION
…ease wait' across all 25 languages

The message is shown in intermediate states (menu building, submenu selection) not only actual download, so 'download started' was misleading. Use neutral 'please wait' wording instead.