### PR TITLE
fix(yt-dlp): treat 'removed for violating TOS' as permanent unavailab…

### DIFF
--- a/DOWN_AND_UP/yt_dlp_hook.py
+++ b/DOWN_AND_UP/yt_dlp_hook.py
@@ -26,6 +26,7 @@ _PERMANENT_UNAVAILABLE_INDICATORS = (
     'video does not exist', 'channel does not exist', 'user does not exist',
     'no longer available', 'video unavailable', 'private video',
     'this content isn\'t available', 'this content is not available',
+    'removed for violating', "terms of service", 'has been removed',
 )
 
 


### PR DESCRIPTION
…le (issue #345)

Added 'removed for violating', 'terms of service', and 'has been removed' to _PERMANENT_UNAVAILABLE_INDICATORS. Previously a video 'removed for violating YouTube's Terms of Service' was not matched by _is_permanent_unavailable(), so get_video_formats fell through into the expensive proxy/impersonate retry chain (~10 retries) instead of returning PERMANENT_UNAVAILABLE immediately. The Always Ask menu already handles PERMANENT_UNAVAILABLE (always_ask_menu.py:5379) and the playlist skip list already has 'removed for violating' (down_and_up.py:82), so this closes the remaining retry storm on TOS-removed videos.