### PR TITLE
fix: install Node.js 22 for yt-dlp EJS YouTube n-challenge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV TZ="$TZ" \
 # - git, ffmpeg, mediainfo, rsync (README: base deps + FFmpeg)
 # - font packages for Arabic/Asian and emoji support (README: optional fonts)
 # - docker.io for dashboard container to manage Docker
-# - nodejs for yt-dlp JS runtime (YouTube extraction)
+# - gnupg + curl for adding the NodeSource apt repo (Node.js installed separately below)
 # - phantomjs removed: deprecated and no longer available in Debian repos
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
@@ -19,8 +19,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     docker.io \
     curl \
     iputils-ping \
-    nodejs \
-    npm \
+    gnupg \
     fonts-noto-core \
     fonts-noto-extra \
     fonts-kacst-one \
@@ -42,6 +41,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /tmp/* /var/tmp/*
+
+# Node.js 22 for yt-dlp's EJS (the YouTube n-challenge / nsig solver). Debian's apt
+# nodejs is < 22, but EJS requires node >= 22 — otherwise every JS challenge provider
+# reports "unavailable" and adaptive formats (720p+/4K) are dropped.
+# https://github.com/yt-dlp/ejs — added the canonical way (GPG key in keyrings +
+# signed-by source list, not the piped setup script).
+RUN mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends nodejs \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- **`Dockerfile`** — stop installing `nodejs`/`npm` from Debian's apt repo (currently **Node 20**) and instead install **Node.js 22** from the NodeSource apt repository, in its own `RUN` layer. Add `gnupg` to the base packages (needed for `gpg --dearmor`).

## Motivation
Recent yt-dlp solves YouTube's n-challenge (nsig) through its **EJS** framework, which requires a JS runtime of **`node >= 22`** (or `deno >= 2.3`). The image ships Node from `apt`, which on the current base is v20 — below EJS's requirement — so at runtime every JS challenge provider reports `unavailable`:

```
[jsc] JS Challenge Providers: bun (unavailable), deno (unavailable), node (unavailable), quickjs (unavailable)
n challenge solving failed: ... Ensure you have a supported JavaScript runtime ...
```

The n-challenge then goes unsolved → web clients fall back to SABR and adaptive formats (720p+/4K) are dropped; some videos even return `No video formats found` / `Requested format is not available` for **non-age-restricted** content. The code already declares `js_runtimes = {'node': {}}` and the README states Node ships in the image — the only missing piece is the version. Ref: https://github.com/yt-dlp/ejs (runtime requirement `node >= 22`).

## Behavior
- **Before:** apt Node v20 → EJS providers `unavailable` → nsig unsolved → `tv` downgraded / web SABR → formats capped low or empty.
- **After:** `node --version` = v22.x inside the container → `[jsc] node (available)` → nsig solved → full adaptive formats (720p+/4K) returned.
- No application code, config, or compose changes — only the image build.

## Design notes / out of scope
- NodeSource repo is added the **canonical apt way** — GPG key in `/etc/apt/keyrings/nodesource.gpg` + `signed-by` entry in `sources.list.d`, distro-agnostic `nodistro` codename — **not** the piped `curl … | bash` setup script.
- Installed in a **separate `RUN`** layer, kept out of the fonts/Amiri block for readability and independent layer caching.
- `deno` (>= 2.3) would also satisfy EJS, but the project explicitly pins `js_runtimes = {'node': {}}` in several places, so bumping Node is the in-project fix; switching to deno would need code changes and is out of scope.

## Known related issue (observed, NOT fixed here)
On videos with a **non-standard resolution** (e.g. 640×352, height 352 rather than 360), the "Always Ask" menu shows `⚠️ Qualities not auto-detected` with no height buttons, because `HELPERS/qualifier.py`'s fixed quality grid maps only exact standard heights (`get_quality_by_min_side` → `"best"` → the format is skipped in `always_ask_menu.py`). The video is still downloadable via **Best** / **Other**. Pre-existing behaviour, unrelated to this change — flagged for visibility; a follow-up could round non-standard heights to the nearest rung.

**Type of Change:** Bug fix

## Test plan
- ✅ Live: container Node bumped from v20 → **v22.19.2**; `[jsc]` turns to `node (available)`, `n challenge solving failed` gone.
- ✅ Live: regular YouTube videos return full formats again (previously capped/empty).
- ⬜ Maintainer: `docker compose build bot && docker exec tg-ytdlp-bot node --version` → v22.x on a clean build.

## Backward compatibility
Build-only change; no config or runtime API touched. Existing deployments just need one image rebuild (`docker compose build`). `engines_updater.sh` (pip-only) does not rebuild the image, so a rebuild is required to pick this up.

## Checklist
- ✅ Follows existing Dockerfile conventions (apt block + dedicated RUN)
- ✅ Self-review completed
- ✅ No application/config changes
- ✅ Single focused fix

## Notes for the maintainer
This likely affects **anyone** who built the image recently, not just this fork — the apt-Node/EJS mismatch silently caps YouTube quality until Node is bumped.
