### PR TITLE
fix: allow trusted cookie-webserver URLs through the SSRF filter

### DIFF
--- a/COMMANDS/cookies_cmd.py
+++ b/COMMANDS/cookies_cmd.py
@@ -14,6 +14,7 @@ from HELPERS.filesystem_hlp import create_directory
 from HELPERS.safe_messeger import fake_message, safe_send_message, safe_edit_message_text
 from pyrogram.errors import FloodWait
 import os
+from functools import lru_cache
 import json
 import requests
 import re
@@ -1203,6 +1204,21 @@ def _sanitize_error_detail(detail: str, url: str) -> str:
     except Exception:
         return "<hidden>"
 
+@lru_cache(maxsize=None)
+def _get_trusted_cookie_urls() -> frozenset[str]:
+    """Exact cookie-fetch URLs the admin configured in Config.*COOKIE_URL are trusted.
+    Substring match (not endswith) covers both COOKIE_URL and YOUTUBE_COOKIE_URL_1..10,
+    while correctly skipping YOUTUBE_COOKIE_TEST_URL / YOUTUBE_COOKIE_ORDER (no 'COOKIE_URL' substring).
+    Cached (frozenset): Config.*COOKIE_URL are static at runtime — config.py changes need a restart."""
+    urls = set()
+    for attr in dir(Config):
+        if "COOKIE_URL" in attr:
+            val = getattr(Config, attr, None)
+            if isinstance(val, str) and val:
+                urls.add(val)
+    return frozenset(urls)
+
+
 def _download_content(url: str, timeout: int = 30, user_id: int | None = None, allow_domain_fallback: bool = True):
     """Скачивает бинарный контент, при необходимости используя пользовательский прокси."""
     if not url:
@@ -1211,7 +1227,7 @@ def _download_content(url: str, timeout: int = 30, user_id: int | None = None, a
     # Валидация URL для предотвращения SSRF
     try:
         from services.lists_service import _validate_url_for_ssrf
-        is_valid, error_msg = _validate_url_for_ssrf(url)
+        is_valid, error_msg = _validate_url_for_ssrf(url, allowed_urls=_get_trusted_cookie_urls())
         if not is_valid:
             logger.warning(f"[COOKIES] Blocked SSRF attempt: {error_msg}")
             return False, None, None, f"invalid-url: {error_msg}"

--- a/services/lists_service.py
+++ b/services/lists_service.py
@@ -175,14 +175,20 @@ def update_lists() -> Dict[str, Any]:
         return {"status": "error", "message": str(e)}
 
 
-def _validate_url_for_ssrf(url: str) -> tuple[bool, str]:
+def _validate_url_for_ssrf(url: str, allowed_urls: set[str] | None = None) -> tuple[bool, str]:
     """
     Валидирует URL для предотвращения SSRF атак.
     Возвращает (is_valid, error_message).
+    allowed_urls: набор точных URL, которым доверяем (напр. cookie-webserver из Config).
+    Они проходят без SSRF-фильтрации хоста. Совпадение строго по полному URL,
+    поэтому послабление не открывает остальной localhost/приватную сеть.
     """
     if not url:
         return False, "URL is empty"
-    
+    # Explicitly trusted exact URLs (e.g. cookie-webserver URLs from Config) bypass the host filter
+    if allowed_urls and url in allowed_urls:
+        return True, ""
+
     try:
         parsed = urlparse(url)
         


### PR DESCRIPTION
## Summary
- **`services/lists_service.py`** — `_validate_url_for_ssrf(url, allowed_urls=None)` gains an optional allowlist; an **exact full-URL** match returns early, before the loopback/private-host checks. Default `None` = current behaviour.
- **`COMMANDS/cookies_cmd.py`** — add `_get_trusted_cookie_urls()` (the exact `Config.*COOKIE_URL` set, memoized with `@lru_cache`) and pass it as `allowed_urls` in `_download_content`'s SSRF check.

## Motivation
Cookie files are fetched from the local `configuration-webserver` over `http://localhost/cookies/...` (the bot shares warp's namespace, so the webserver is only reachable via localhost). The SSRF validator rejects loopback hosts, so cookie auto-download fails:

```
[COOKIES] Blocked SSRF attempt: Blocked hostname: localhost
Failed to download YouTube cookies from source 1
```

Cookie-fetch URLs come **exclusively** from `Config.*COOKIE_URL` (admin-set, never user input — verified across all call sites of `_download_content`), so those exact URLs can safely bypass the host filter.

## Behavior
- **Before:** `*_COOKIE_URL = http://localhost/...` → SSRF block → cookies never auto-download → cookie-required videos fail unless the user manually `/cookie`-uploads.
- **After:** exactly the configured `Config.*COOKIE_URL` bypass the host filter → cookies auto-download from the webserver. Every other localhost/private host is still blocked.

## Design notes / out of scope
- **Exact full-URL match, not a host allowlist** — allowing the host `localhost` would open the entire loopback; matching the exact configured URL keeps the rest of localhost and the private network blocked.
- The bypass is scoped to the **cookie-download path only**. There are three independent copies of `_validate_url_for_ssrf` (`lists_service.py`, `URL_PARSERS/service_api_info.py`, `URL_PARSERS/thumbnail_downloader.py`); only the cookie path passes `allowed_urls`, so user-supplied URLs (thumbnails, api-info) keep full SSRF protection.
- `_get_trusted_cookie_urls()` filters `Config` attributes by the substring `"COOKIE_URL"` (covers `COOKIE_URL` and `YOUTUBE_COOKIE_URL_1..10`; correctly skips `YOUTUBE_COOKIE_TEST_URL` / `YOUTUBE_COOKIE_ORDER`). Cached with `lru_cache` since `Config.*COOKIE_URL` are static at runtime.
- Companion to *"restore optional configuration-webserver"* — that PR sets up the localhost webserver this fix unblocks.

**Type of Change:** Bug fix

## Test plan
- ✅ Syntax: `python -m compileall services/lists_service.py COMMANDS/cookies_cmd.py` clean.
- ✅ `_validate_url_for_ssrf(url)` (no allowlist) unchanged; `allowed_urls={url}` returns `(True, "")`.
- ⬜ Live: with `*_COOKIE_URL = http://localhost/...`, a cookie-required download auto-fetches cookies (no SSRF block in logs).
- ⬜ A user-facing localhost/private-IP request (thumbnail/list fetch) is still blocked.

## Backward compatibility
`allowed_urls` defaults to `None` (existing behaviour). Other `_validate_url_for_ssrf` callers are untouched. No config migration.

## Checklist
- ✅ Follows existing code style (optional param, local import pattern)
- ✅ Self-review completed
- ✅ Scoped strictly to the cookie-download path; user URLs unaffected
- ✅ Single focused fix

## Notes for the maintainer
The trust boundary is deliberate: only URLs the operator themselves put in `Config.*COOKIE_URL` are allowed; a user cannot influence `Config`, so cannot reach the allowlist. This is the companion fix to the configuration-webserver PR — together they enable automatic cookie distribution over localhost.
