### PR TITLE
feat: add ALLOWED_USERS private-chat whitelist

### DIFF
--- a/CONFIG/LANGUAGES/messages_AR.py
+++ b/CONFIG/LANGUAGES/messages_AR.py
@@ -787,6 +787,7 @@ class Messages(object):
     # Admin command messages
     ADMIN_ACCESS_DENIED_MSG = "❌ تم رفض الوصول. للمدير فقط."
     ACCESS_DENIED_ADMIN = "❌ تم رفض الوصول. للمدير فقط."
+    ACCESS_DENIED_PRIVATE_MSG = "⛔ تم رفض الوصول. هذا البوت خاص."
     WELCOME_MASTER = "مرحباً أيها السيد 🥷"
     DOWNLOAD_ERROR_GENERIC = "❌ عذراً... حدث خطأ أثناء التحميل."
     SIZE_LIMIT_EXCEEDED = "❌ حجم الملف يتجاوز الحد الأقصى {max_size_gb} جيجابايت. يرجى اختيار ملف أصغر ضمن الحجم المسموح."

--- a/CONFIG/LANGUAGES/messages_BN.py
+++ b/CONFIG/LANGUAGES/messages_BN.py
@@ -787,6 +787,7 @@ class Messages(object):
     # Admin command messages
     ADMIN_ACCESS_DENIED_MSG = "❌ অ্যাক্সেস অস্বীকার করা হয়েছে। শুধুমাত্র অ্যাডমিন।"
     ACCESS_DENIED_ADMIN = "❌ অ্যাক্সেস অস্বীকার করা হয়েছে। শুধুমাত্র অ্যাডমিন।"
+    ACCESS_DENIED_PRIVATE_MSG = "⛔ অ্যাক্সেস অস্বীকৃত। এই বটটি ব্যক্তিগত।"
     WELCOME_MASTER = "স্বাগতম মাস্টার 🥷"
     DOWNLOAD_ERROR_GENERIC = "❌ দুঃখিত... ডাউনলোডের সময় কিছু ত্রুটি ঘটেছে।"
     SIZE_LIMIT_EXCEEDED = "❌ ফাইলের আকার {max_size_gb} GB সীমা অতিক্রম করেছে। অনুগ্রহ করে অনুমোদিত আকারের মধ্যে একটি ছোট ফাইল নির্বাচন করুন।"

--- a/CONFIG/LANGUAGES/messages_DE.py
+++ b/CONFIG/LANGUAGES/messages_DE.py
@@ -787,6 +787,7 @@ Mehr erfahren: /playlist"""
     # Admin command messages
     ADMIN_ACCESS_DENIED_MSG = "❌ Zugriff verweigert. Nur für Administratoren."
     ACCESS_DENIED_ADMIN = "❌ Zugriff verweigert. Nur für Administratoren."
+    ACCESS_DENIED_PRIVATE_MSG = "⛔ Zugriff verweigert. Dieser Bot ist privat."
     WELCOME_MASTER = "Willkommen Meister 🥷"
     DOWNLOAD_ERROR_GENERIC = "❌ Entschuldigung... Beim Download ist ein Fehler aufgetreten."
     SIZE_LIMIT_EXCEEDED = "❌ Die Dateigröße überschreitet das Limit von {max_size_gb} GB. Bitte wählen Sie eine kleinere Datei innerhalb der erlaubten Größe."

--- a/CONFIG/LANGUAGES/messages_EN.py
+++ b/CONFIG/LANGUAGES/messages_EN.py
@@ -785,6 +785,7 @@ Learn more: /playlist"""
     # Admin command messages
     ADMIN_ACCESS_DENIED_MSG = "❌ Access denied. Admin only."
     ACCESS_DENIED_ADMIN = "❌ Access denied. Admin only."
+    ACCESS_DENIED_PRIVATE_MSG = "⛔ Access denied. This bot is private."
     WELCOME_MASTER = "Welcome Master 🥷"
     DOWNLOAD_ERROR_GENERIC = "❌ Sorry... Some error occurred during download."
     SIZE_LIMIT_EXCEEDED = "❌ The file size exceeds the {max_size_gb} GB limit. Please select a smaller file within the allowed size."

--- a/CONFIG/LANGUAGES/messages_ES.py
+++ b/CONFIG/LANGUAGES/messages_ES.py
@@ -787,6 +787,7 @@ Más información: /playlist"""
     # Admin command messages
     ADMIN_ACCESS_DENIED_MSG = "❌ Acceso denegado. Solo administradores."
     ACCESS_DENIED_ADMIN = "❌ Acceso denegado. Solo administradores."
+    ACCESS_DENIED_PRIVATE_MSG = "⛔ Acceso denegado. Este bot es privado."
     WELCOME_MASTER = "Bienvenido Maestro 🥷"
     DOWNLOAD_ERROR_GENERIC = "❌ Lo siento... Ocurrió algún error durante la descarga."
     SIZE_LIMIT_EXCEEDED = "❌ El tamaño del archivo excede el límite de {max_size_gb} GB. Por favor selecciona un archivo más pequeño dentro del tamaño permitido."

--- a/CONFIG/LANGUAGES/messages_FA.py
+++ b/CONFIG/LANGUAGES/messages_FA.py
@@ -787,6 +787,7 @@ class Messages(object):
     # Admin command messages
     ADMIN_ACCESS_DENIED_MSG = "❌ دسترسی رد شد. فقط مدیر."
     ACCESS_DENIED_ADMIN = "❌ دسترسی رد شد. فقط مدیر."
+    ACCESS_DENIED_PRIVATE_MSG = "⛔ دسترسی رد شد. این ربات خصوصی است."
     WELCOME_MASTER = "خوش آمدید ارباب 🥷"
     DOWNLOAD_ERROR_GENERIC = "❌ متأسفم... خطایی در حین دانلود رخ داد."
     SIZE_LIMIT_EXCEEDED = "❌ اندازه فایل از محدودیت {max_size_gb} GB تجاوز می‌کند. لطفاً فایلی کوچکتر در اندازه مجاز انتخاب کنید."

--- a/CONFIG/LANGUAGES/messages_FR.py
+++ b/CONFIG/LANGUAGES/messages_FR.py
@@ -787,6 +787,7 @@ En savoir plus : /playlist"""
     # Admin command messages
     ADMIN_ACCESS_DENIED_MSG = "❌ Accès refusé. Administrateurs uniquement."
     ACCESS_DENIED_ADMIN = "❌ Accès refusé. Administrateurs uniquement."
+    ACCESS_DENIED_PRIVATE_MSG = "⛔ Accès refusé. Ce bot est privé."
     WELCOME_MASTER = "Bienvenue Maître 🥷"
     DOWNLOAD_ERROR_GENERIC = "❌ Désolé... Une erreur s'est produite lors du téléchargement."
     SIZE_LIMIT_EXCEEDED = "❌ La taille du fichier dépasse la limite de {max_size_gb} Go. Veuillez sélectionner un fichier plus petit dans la taille autorisée."

--- a/CONFIG/LANGUAGES/messages_HA.py
+++ b/CONFIG/LANGUAGES/messages_HA.py
@@ -788,6 +788,7 @@ Koyi ƙari: /playlist"""
     # Admin command messages
     ADMIN_ACCESS_DENIED_MSG = "❌ An ƙi dama. Admin kawai."
     ACCESS_DENIED_ADMIN = "❌ An ƙi dama. Admin kawai."
+    ACCESS_DENIED_PRIVATE_MSG = "⛔ An hana damar shiga. Wannan bot na sirri ne."
     WELCOME_MASTER = "Barka da zuwa Jagora 🥷"
     DOWNLOAD_ERROR_GENERIC = "❌ Yi hakuri... Wani kuskure ya faru yayin saukewa."
     SIZE_LIMIT_EXCEEDED = "❌ Girman fayil ya wuce iyakar {max_size_gb} GB. Da fatan za a zaɓi fayil ƙarami a cikin girman da aka yarda."

--- a/CONFIG/LANGUAGES/messages_ID.py
+++ b/CONFIG/LANGUAGES/messages_ID.py
@@ -787,6 +787,7 @@ Pelajari lebih lanjut: /playlist"""
     # Admin command messages
     ADMIN_ACCESS_DENIED_MSG = "❌ Akses ditolak. Hanya admin."
     ACCESS_DENIED_ADMIN = "❌ Akses ditolak. Hanya admin."
+    ACCESS_DENIED_PRIVATE_MSG = "⛔ Akses ditolak. Bot ini bersifat pribadi."
     WELCOME_MASTER = "Selamat Datang Tuan 🥷"
     DOWNLOAD_ERROR_GENERIC = "❌ Maaf... Terjadi kesalahan saat mengunduh."
     SIZE_LIMIT_EXCEEDED = "❌ Ukuran file melebihi batas {max_size_gb} GB. Silakan pilih file yang lebih kecil dalam ukuran yang diizinkan."

--- a/CONFIG/LANGUAGES/messages_IN.py
+++ b/CONFIG/LANGUAGES/messages_IN.py
@@ -786,6 +786,7 @@ class Messages(object):
     # Admin command messages
     ADMIN_ACCESS_DENIED_MSG = "❌ पहुंच अस्वीकृत। केवल व्यवस्थापक।"
     ACCESS_DENIED_ADMIN = "❌ पहुंच अस्वीकृत। केवल व्यवस्थापक।"
+    ACCESS_DENIED_PRIVATE_MSG = "⛔ पहुँच अस्वीकृत। यह बॉट निजी है।"
     WELCOME_MASTER = "स्वागत है मास्टर 🥷"
     DOWNLOAD_ERROR_GENERIC = "❌ क्षमा करें... डाउनलोड के दौरान कुछ त्रुटि हुई।"
     SIZE_LIMIT_EXCEEDED = "❌ फाइल का आकार {max_size_gb} GB सीमा से अधिक है। कृपया अनुमतित आकार के भीतर एक छोटी फाइल चुनें।"

--- a/CONFIG/LANGUAGES/messages_IT.py
+++ b/CONFIG/LANGUAGES/messages_IT.py
@@ -787,6 +787,7 @@ Scopri di più: /playlist"""
     # Admin command messages
     ADMIN_ACCESS_DENIED_MSG = "❌ Accesso negato. Solo amministratore."
     ACCESS_DENIED_ADMIN = "❌ Accesso negato. Solo amministratore."
+    ACCESS_DENIED_PRIVATE_MSG = "⛔ Accesso negato. Questo bot è privato."
     WELCOME_MASTER = "Benvenuto Maestro 🥷"
     DOWNLOAD_ERROR_GENERIC = "❌ Spiacenti... Si è verificato un errore durante il download."
     SIZE_LIMIT_EXCEEDED = "❌ La dimensione del file supera il limite di {max_size_gb} GB. Seleziona un file più piccolo entro le dimensioni consentite."

--- a/CONFIG/LANGUAGES/messages_JA.py
+++ b/CONFIG/LANGUAGES/messages_JA.py
@@ -787,6 +787,7 @@ class Messages(object):
     # Admin command messages
     ADMIN_ACCESS_DENIED_MSG = "❌ アクセスが拒否されました。管理者のみ。"
     ACCESS_DENIED_ADMIN = "❌ アクセスが拒否されました。管理者のみ。"
+    ACCESS_DENIED_PRIVATE_MSG = "⛔ アクセスが拒否されました。このボットはプライベートです。"
     WELCOME_MASTER = "マスター、ようこそ 🥷"
     DOWNLOAD_ERROR_GENERIC = "❌ 申し訳ございません... ダウンロード中にエラーが発生しました。"
     SIZE_LIMIT_EXCEEDED = "❌ ファイルサイズが{max_size_gb}GBの制限を超えています。許可されたサイズ内でより小さなファイルを選択してください。"

--- a/CONFIG/LANGUAGES/messages_KK.py
+++ b/CONFIG/LANGUAGES/messages_KK.py
@@ -788,6 +788,7 @@ class Messages(object):
     # Admin command messages
     ADMIN_ACCESS_DENIED_MSG = "❌ Қол жеткізу қол жетімсіз. Тек әкімші."
     ACCESS_DENIED_ADMIN = "❌ Қол жеткізу қол жетімсіз. Тек әкімші."
+    ACCESS_DENIED_PRIVATE_MSG = "⛔ Қол жеткізу тыйым салынған. Бұл бот жеке."
     WELCOME_MASTER = "Қош келдіңіз, Қожайын 🥷"
     DOWNLOAD_ERROR_GENERIC = "❌ Кешіріңіз... Жүктеу кезінде қате орын алды."
     SIZE_LIMIT_EXCEEDED = "❌ Файл өлшемі {max_size_gb} GB шегінен асып кетті. Рұқсат етілген өлшем ішінде кішірек файлды таңдаңыз."

--- a/CONFIG/LANGUAGES/messages_KO.py
+++ b/CONFIG/LANGUAGES/messages_KO.py
@@ -787,6 +787,7 @@ class Messages(object):
     # Admin command messages
     ADMIN_ACCESS_DENIED_MSG = "❌ 접근이 거부되었습니다. 관리자만 가능합니다."
     ACCESS_DENIED_ADMIN = "❌ 접근이 거부되었습니다. 관리자만 가능합니다."
+    ACCESS_DENIED_PRIVATE_MSG = "⛔ 접근이 거부되었습니다. 이 봇은 비공개입니다."
     WELCOME_MASTER = "환영합니다 관리자님 🥷"
     DOWNLOAD_ERROR_GENERIC = "❌ 죄송합니다... 다운로드 중 오류가 발생했습니다."
     SIZE_LIMIT_EXCEEDED = "❌ 파일 크기가 {max_size_gb} GB 제한을 초과했습니다. 허용된 크기 내에서 더 작은 파일을 선택해주세요."

--- a/CONFIG/LANGUAGES/messages_PL.py
+++ b/CONFIG/LANGUAGES/messages_PL.py
@@ -6,6 +6,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 from CONFIG.config import Config
 
 class Messages(object):
+    ACCESS_DENIED_PRIVATE_MSG = "⛔ Brak dostępu. Ten bot jest prywatny."
     #######################################################
     # Messages and errors
     #######################################################

--- a/CONFIG/LANGUAGES/messages_PT.py
+++ b/CONFIG/LANGUAGES/messages_PT.py
@@ -787,6 +787,7 @@ Saiba mais: /playlist"""
     # Admin command messages
     ADMIN_ACCESS_DENIED_MSG = "❌ Acesso negado. Apenas administrador."
     ACCESS_DENIED_ADMIN = "❌ Acesso negado. Apenas administrador."
+    ACCESS_DENIED_PRIVATE_MSG = "⛔ Acesso negado. Este bot é privado."
     WELCOME_MASTER = "Bem-vindo Mestre 🥷"
     DOWNLOAD_ERROR_GENERIC = "❌ Desculpe... Ocorreu algum erro durante o download."
     SIZE_LIMIT_EXCEEDED = "❌ O tamanho do arquivo excede o limite de {max_size_gb} GB. Por favor, selecione um arquivo menor dentro do tamanho permitido."

--- a/CONFIG/LANGUAGES/messages_RU.py
+++ b/CONFIG/LANGUAGES/messages_RU.py
@@ -786,6 +786,7 @@ class Messages(object):
     # Admin command messages
     ADMIN_ACCESS_DENIED_MSG = "❌ Доступ запрещен. Только для администраторов."
     ACCESS_DENIED_ADMIN = "❌ Доступ запрещен. Только для администраторов."
+    ACCESS_DENIED_PRIVATE_MSG = "⛔ Доступ запрещен. Этот бот приватный."
     WELCOME_MASTER = "Добро пожаловать, Мастер 🥷"
     DOWNLOAD_ERROR_GENERIC = "❌ Извините... Произошла ошибка во время загрузки."
     SIZE_LIMIT_EXCEEDED = "❌ Размер файла превышает лимит {max_size_gb} ГБ. Пожалуйста, выберите файл меньшего размера в пределах допустимого."

--- a/CONFIG/LANGUAGES/messages_TH.py
+++ b/CONFIG/LANGUAGES/messages_TH.py
@@ -787,6 +787,7 @@ class Messages(object):
     # Admin command messages
     ADMIN_ACCESS_DENIED_MSG = "❌ การเข้าถึงถูกปฏิเสธ ผู้ดูแลระบบเท่านั้น"
     ACCESS_DENIED_ADMIN = "❌ การเข้าถึงถูกปฏิเสธ ผู้ดูแลระบบเท่านั้น"
+    ACCESS_DENIED_PRIVATE_MSG = "⛔ การเข้าถึงถูกปฏิเสธ บอทนี้เป็นบอทส่วนตัว"
     WELCOME_MASTER = "ยินดีต้อนรับท่านอาจารย์ 🥷"
     DOWNLOAD_ERROR_GENERIC = "❌ ขออภัย... มีข้อผิดพลาดเกิดขึ้นระหว่างการดาวน์โหลด"
     SIZE_LIMIT_EXCEEDED = "❌ ขนาดไฟล์เกินขีดจำกัด {max_size_gb} GB โปรดเลือกไฟล์ที่มีขนาดเล็กกว่าในขนาดที่อนุญาต"

--- a/CONFIG/LANGUAGES/messages_TL.py
+++ b/CONFIG/LANGUAGES/messages_TL.py
@@ -788,6 +788,7 @@ Matuto pa: /playlist"""
     # Admin command messages
     ADMIN_ACCESS_DENIED_MSG = "❌ Tinanggihan ang pag-access. Admin lang."
     ACCESS_DENIED_ADMIN = "❌ Tinanggihan ang pag-access. Admin lang."
+    ACCESS_DENIED_PRIVATE_MSG = "⛔ Tinanggihan ang pag-access. Pribado ang bot na ito."
     WELCOME_MASTER = "Maligayang pagdating Master 🥷"
     DOWNLOAD_ERROR_GENERIC = "❌ Paumanhin... May naganap na error habang nagda-download."
     SIZE_LIMIT_EXCEEDED = "❌ Ang laki ng file ay lumampas sa {max_size_gb} GB na limitasyon. Mangyaring pumili ng mas maliit na file sa loob ng pinapayagang laki."

--- a/CONFIG/LANGUAGES/messages_TR.py
+++ b/CONFIG/LANGUAGES/messages_TR.py
@@ -787,6 +787,7 @@ Daha fazla bilgi: /playlist"""
     # Admin command messages
     ADMIN_ACCESS_DENIED_MSG = "❌ Erişim reddedildi. Yalnızca yönetici."
     ACCESS_DENIED_ADMIN = "❌ Erişim reddedildi. Yalnızca yönetici."
+    ACCESS_DENIED_PRIVATE_MSG = "⛔ Erişim reddedildi. Bu bot özeldir."
     WELCOME_MASTER = "Hoş geldiniz Usta 🥷"
     DOWNLOAD_ERROR_GENERIC = "❌ Üzgünüm... İndirme sırasında bir hata oluştu."
     SIZE_LIMIT_EXCEEDED = "❌ Dosya boyutu {max_size_gb} GB sınırını aşıyor. Lütfen izin verilen boyut dahilinde daha küçük bir dosya seçin."

--- a/CONFIG/LANGUAGES/messages_UK.py
+++ b/CONFIG/LANGUAGES/messages_UK.py
@@ -787,6 +787,7 @@ class Messages(object):
     # Admin command messages
     ADMIN_ACCESS_DENIED_MSG = "❌ Доступ заборонено. Лише адміністратор."
     ACCESS_DENIED_ADMIN = "❌ Доступ заборонено. Лише адміністратор."
+    ACCESS_DENIED_PRIVATE_MSG = "⛔ Доступ заборонено. Цей бот приватний."
     WELCOME_MASTER = "Ласкаво просимо, Майстре 🥷"
     DOWNLOAD_ERROR_GENERIC = "❌ Вибачте... Під час завантаження сталася помилка."
     SIZE_LIMIT_EXCEEDED = "❌ Розмір файлу перевищує {max_size_gb} Гб. Будь ласка, виберіть менший файл у межах дозволеного розміру."

--- a/CONFIG/LANGUAGES/messages_UR.py
+++ b/CONFIG/LANGUAGES/messages_UR.py
@@ -788,6 +788,7 @@ Use:
     # Admin command messages
     ADMIN_ACCESS_DENIED_MSG = "❌ Access denied. Admin only."
     ACCESS_DENIED_ADMIN = "❌ رسائی سے انکار. صرف ایڈمن۔"
+    ACCESS_DENIED_PRIVATE_MSG = "⛔ رسائی سے انکار۔ یہ بوٹ نجی ہے۔"
     WELCOME_MASTER = "خوش آمدید ماسٹر 🥷"
     DOWNLOAD_ERROR_GENERIC = "❌ معذرت ... ڈاؤن لوڈ کے دوران کچھ خرابی پیش آگئی۔"
     SIZE_LIMIT_EXCEEDED = "❌ فائل کا سائز {max_size_gb} GB حد سے تجاوز کرتا ہے۔ براہ کرم اجازت شدہ سائز میں ایک چھوٹی فائل منتخب کریں۔"

--- a/CONFIG/LANGUAGES/messages_UZ.py
+++ b/CONFIG/LANGUAGES/messages_UZ.py
@@ -787,6 +787,7 @@ Ko'proq ma'lumot: /playlist"""
     # Admin command messages
     ADMIN_ACCESS_DENIED_MSG = "❌ Kirish rad etildi. Faqat admin."
     ACCESS_DENIED_ADMIN = "❌ Kirish rad etildi. Faqat admin."
+    ACCESS_DENIED_PRIVATE_MSG = "⛔ Kirish rad etildi. Bu bot shaxsiy."
     WELCOME_MASTER = "Xush kelibsiz, Usta 🥷"
     DOWNLOAD_ERROR_GENERIC = "❌ Kechirasiz... Yuklab olish paytida xatolik yuz berdi."
     SIZE_LIMIT_EXCEEDED = "❌ Fayl hajmi {max_size_gb} GB chegarasidan oshib ketdi. Iltimos, ruxsat etilgan hajm ichida kichikroq faylni tanlang."

--- a/CONFIG/LANGUAGES/messages_VI.py
+++ b/CONFIG/LANGUAGES/messages_VI.py
@@ -787,6 +787,7 @@ Tìm hiểu thêm: /playlist"""
     # Admin command messages
     ADMIN_ACCESS_DENIED_MSG = "❌ Truy cập bị từ chối. Chỉ dành cho admin."
     ACCESS_DENIED_ADMIN = "❌ Truy cập bị từ chối. Chỉ dành cho admin."
+    ACCESS_DENIED_PRIVATE_MSG = "⛔ Truy cập bị từ chối. Bot này ở chế độ riêng tư."
     WELCOME_MASTER = "Chào mừng Thầy 🥷"
     DOWNLOAD_ERROR_GENERIC = "❌ Xin lỗi... Đã xảy ra lỗi trong quá trình tải xuống."
     SIZE_LIMIT_EXCEEDED = "❌ Kích thước tệp vượt quá giới hạn {max_size_gb} GB. Vui lòng chọn tệp nhỏ hơn trong phạm vi kích thước được phép."

--- a/CONFIG/LANGUAGES/messages_ZH.py
+++ b/CONFIG/LANGUAGES/messages_ZH.py
@@ -787,6 +787,7 @@ class Messages(object):
     # Admin command messages
     ADMIN_ACCESS_DENIED_MSG = "❌ 访问被拒绝。仅限管理员。"
     ACCESS_DENIED_ADMIN = "❌ 访问被拒绝。仅限管理员。"
+    ACCESS_DENIED_PRIVATE_MSG = "⛔ 访问被拒绝。此机器人是私有的。"
     WELCOME_MASTER = "欢迎主人 🥷"
     DOWNLOAD_ERROR_GENERIC = "❌ 抱歉...下载过程中发生了一些错误。"
     SIZE_LIMIT_EXCEEDED = "❌ 文件大小超过 {max_size_gb} GB 限制。请在允许的大小范围内选择较小的文件。"

--- a/CONFIG/_config.py
+++ b/CONFIG/_config.py
@@ -23,6 +23,8 @@ class Config(object):
     # Add allowed group IDs - Only these groups will be served by the bot
     ADMIN_GROUP = [-100111111111111, -1002222222222222]
     ALLOWED_GROUP = [-100111111111111, -1002222222222222]
+    # Restrict private chat usage to these user IDs only (empty list = everyone allowed)
+    ALLOWED_USERS = []
     # API ID Telegram
     API_ID = 00000000000000
     # API HASH Telegram

--- a/CONFIG/logger_msg.py
+++ b/CONFIG/logger_msg.py
@@ -269,6 +269,7 @@ class LoggerMsg(object):
     LIMITTER_CHANNEL_CHECK_IS_MEMBER_LOG_MSG = "[CHANNEL_CHECK] User {user_id} is member of channel"
     LIMITTER_CHANNEL_CHECK_NOT_MEMBER_LOG_MSG = "[CHANNEL_CHECK] User {user_id} is not member of channel"
     LIMITTER_CHANNEL_CHECK_ERROR_LOG_MSG = "Error checking channel membership for user {user_id}: {error}"
+    LIMITTER_USER_NOT_ALLOWED_LOG_MSG = "User {user_id} is not in ALLOWED_USERS — private access denied"
     LIMITTER_SUBTITLE_LIMITS_CHECK_PASSED_LOG_MSG = "Subtitle limits check passed: duration={duration}s, size={size} bytes, quality={width}x{height}"
     LIMITTER_SUBTITLE_LIMITS_CHECK_ERROR_LOG_MSG = "Error checking subtitle limits: {error}"
     

--- a/HELPERS/limitter.py
+++ b/HELPERS/limitter.py
@@ -133,6 +133,26 @@ def _send_subscribe_prompt(chat_id):
     )
 
 
+def is_user_allowed(message):
+    """ALLOWED_USERS whitelist for private chats.
+    Empty list = disabled (everyone allowed). Admins always pass.
+    Groups are unaffected (private chats only)."""
+    allowed_users = getattr(Config, 'ALLOWED_USERS', [])
+    if not allowed_users:
+        return True
+    if getattr(message.chat, 'type', None) != enums.ChatType.PRIVATE:
+        return True
+    try:
+        user_id = int(getattr(message.chat, 'id', 0))
+    except Exception:
+        return True
+    if user_id in Config.ADMIN or user_id in allowed_users:
+        return True
+    logger.info(LoggerMsg.LIMITTER_USER_NOT_ALLOWED_LOG_MSG.format(user_id=user_id))
+    safe_send_message(user_id, safe_get_messages(user_id).ACCESS_DENIED_PRIVATE_MSG)
+    return False
+
+
 def is_user_in_channel(app, message):
     _messages = safe_get_messages(message.chat.id)
     # Bypass subscription checks for explicitly allowed groups and admin groups
@@ -142,6 +162,9 @@ def is_user_in_channel(app, message):
             return True
     except Exception:
         pass
+    # ALLOWED_USERS whitelist check (private chats only)
+    if not is_user_allowed(message):
+        return False  # denial message already sent by is_user_allowed
     try:
         logger.info(LoggerMsg.LIMITTER_CHANNEL_CHECK_MEMBERSHIP_LOG_MSG.format(
             user_id=message.chat.id, channel=Config.SUBSCRIBE_CHANNEL))

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Then edit `CONFIG/config.py` and fill in at least:
 - **ADMIN_USERNAME** – admin username (e.g., `"@"` or `"@your_username"`)
 - **ADMIN_GROUP** – list of admin group IDs (groups that bypass all limits, optional but recommended)
 - **ALLOWED_GROUP** – list of allowed group IDs (groups with increased limits, optional but recommended)
+- **ALLOWED_USERS** – list of user IDs allowed to use the bot in private chats; empty list (default) means everyone is allowed (optional)
 - **API_ID**, **API_HASH** – from [my.telegram.org](https://my.telegram.org) (see section [Getting API Credentials](#getting-api-credentials))
 - **BOT_TOKEN** – from [@BotFather](https://t.me/BotFather) (see section [Getting API Credentials](#getting-api-credentials))
 - **LOGS\_*** (LOGS_ID, LOGS_VIDEO_ID, LOGS_NSFW_ID, LOGS_IMG_ID, LOGS_PAID_ID, LOG_EXCEPTION) – Fill in all the fields, if you want you can use the same channel for all
@@ -161,6 +162,7 @@ ADMIN = [123456789]                          # List of admin user IDs
 ADMIN_USERNAME = "@"                         # Admin username (e.g., "@" or "@your_username")
 ADMIN_GROUP = [-1001234567890]               # List of admin group IDs (groups that bypass all limits)
 ALLOWED_GROUP = [-1001234567890]             # List of allowed group IDs (groups with increased limits)
+ALLOWED_USERS = []                           # Private-chat whitelist of user IDs (empty = everyone allowed)
 API_ID = 12345678                            # Your Telegram API ID
 API_HASH = "your_api_hash_here"              # Your Telegram API Hash
 BOT_TOKEN = "1234567890:ABCdefGHIjklMNOpqrsTUVwxyz"  # Your bot token

--- a/README_RU.md
+++ b/README_RU.md
@@ -253,6 +253,7 @@ cp CONFIG/_config.py CONFIG/config.py
 - **ADMIN_USERNAME** – ваш username (например `"@"` или `"@username"`)
 - **ADMIN_GROUP** – ID групп админов (опционально)
 - **ALLOWED_GROUP** – ID разрешенных групп (опционально)
+- **ALLOWED_USERS** – ID пользователей, которым разрешён бот в личных чатах; пустой список (по умолчанию) — доступ всем (опционально)
 - **API_ID**, **API_HASH** – из [my.telegram.org](https://my.telegram.org)
 - **BOT_TOKEN** – из [@BotFather](https://t.me/BotFather)
 - **LOGS_*** – все лог-каналы
@@ -272,6 +273,7 @@ ADMIN = [123456789]                          # Список ID админов
 ADMIN_USERNAME = "@"                         # Admin username
 ADMIN_GROUP = [-1001234567890]               # ID групп админов
 ALLOWED_GROUP = [-1001234567890]             # ID разрешенных групп
+ALLOWED_USERS = []                           # Белый список ID для личных чатов (пусто = доступ всем)
 API_ID = 12345678                            # Ваш Telegram API ID
 API_HASH = "your_api_hash_here"              # Ваш Telegram API Hash
 BOT_TOKEN = "1234567890:ABCdefGHIjklMNOpqrsTUVwxyz"  # Токен бота

--- a/URL_PARSERS/url_extractor.py
+++ b/URL_PARSERS/url_extractor.py
@@ -4,7 +4,7 @@
 # Text Message Handler for General Commands
 from HELPERS.app_instance import get_app
 from HELPERS.decorators import reply_with_keyboard, background_handler
-from HELPERS.limitter import is_user_in_channel, check_user
+from HELPERS.limitter import is_user_in_channel, check_user, is_user_allowed
 from HELPERS.logger import send_to_all, send_to_logger, send_to_user
 from CONFIG.logger_msg import LoggerMsg, get_logger_msg
 from CONFIG.messages import Messages, safe_get_messages
@@ -123,6 +123,10 @@ def url_distractor(app, message):
             if is_user_blocked(message):
                 return  # User is blocked, message already sent by is_user_blocked
     
+    # ALLOWED_USERS whitelist (private only, admins always allowed)
+    if not is_admin and not is_user_allowed(message):
+        return  # denial message already sent by is_user_allowed
+
     # Anti-bot protection check
     from HELPERS.anti_bot_protection import check_and_ban_user, record_user_activity
     from CONFIG.messages import safe_get_messages


### PR DESCRIPTION
## Summary
Add an optional `ALLOWED_USERS` whitelist so an instance can be limited to a known set of people in private chats (plus the existing `ADMIN`). When the list is empty (the default) nothing changes — the bot stays public exactly as today.

- **`CONFIG/_config.py`** — new `ALLOWED_USERS = []` setting next to `ADMIN` / `ALLOWED_GROUP`, read via `getattr(Config, 'ALLOWED_USERS', [])` (backward-compatible with existing `config.py` files).
- **`HELPERS/limitter.py`** — new predicate `is_user_allowed(message)` plus a check inside `is_user_in_channel()` immediately after the group bypass. Because the private command handlers already call `is_user_in_channel()`, this single insertion covers all of them with **zero edits to the command modules**.
- **`URL_PARSERS/url_extractor.py`** — an early gate at the top of `url_distractor()` right after the `blocked` check, covering the paths that run *before* the main subscription gate (emoji dispatcher, `/start`, `/help`, `/lang`, args-import).
- **`CONFIG/logger_msg.py`** — `LIMITTER_USER_NOT_ALLOWED_LOG_MSG`.
- **`CONFIG/LANGUAGES/messages_*.py`** — `ACCESS_DENIED_PRIVATE_MSG` added to **all 25** language files.
- **`README.md` / `README_RU.md`** — document the setting.

## Motivation
There is currently no built-in way to run a private instance limited to specific people. Someone self-hosting for friends/family can only rely on the channel-subscription gate, which controls *whether* a user is subscribed, not *who* is allowed. `ALLOWED_USERS` adds a minimal allow-list for private deployments. Pairs naturally with the *"make channel subscription optional"* PR: together they let a friends-only instance run purely on the whitelist, with no subscription channel required. No existing issue tracks this, so it is opened as a standalone enhancement.

## Behavior
- **Empty list (default):** feature off, behaviour byte-for-byte unchanged. Fully backward compatible, no config migration.
- **Non-empty list:** in private chats only the listed IDs (∪ `ADMIN`) are served; anyone else gets **one** localized "access denied" message.
- **Admins always pass** — both at the call sites (`not is_admin and ...`) and inside the predicate itself.
- **Subscription still applies.** The whitelist sits *before* the `SUBSCRIBE_CHANNEL` check, so an allowed non-admin is still asked to subscribe as before — the whitelist **restricts**, it does not grant access.
- **Groups are untouched.** Group access stays governed by `ALLOWED_GROUP`; the predicate returns early for any non-`PRIVATE` chat.
- **Style.** The predicate sends its own denial message and returns a bool — mirroring the existing `is_user_blocked` / `is_user_in_channel` idiom, not a new pattern. No middleware, no handler groups.

## Design notes / out of scope (on purpose)
- **Implemented within the project's existing access architecture, not a new pattern.** The whitelist hooks into the same gates the project already uses — `is_user_in_channel` (which the command handlers funnel through) plus the early `url_distractor` check — rather than introducing middleware. This deliberately preserves how the project already treats callbacks, and that treatment is already safe: inline menus (`askq`/`askf`) are only produced in response to a message that has **already passed the message gate**, so an outsider never receives buttons in the first place — the callback handlers are effectively unreachable without first clearing the gate. Adding `ALLOWED_USERS` at those same gate points only **strengthens** that barrier (outsiders are filtered one step earlier) and does not weaken it. If you'd want belt-and-braces coverage regardless, a global pre-handler in a dedicated Pyrogram handler group could gate messages + callbacks + pipeline in one place — but that is a larger architectural change we intentionally avoided, to stay in the project's style and keep the diff minimal.
- **Runtime management not included.** A `/auth`-style command with persistence was intentionally left out to keep this a single static config value, consistent with how `ADMIN` / `ALLOWED_GROUP` are configured. Could be a follow-up.

## Pre-existing quirks observed (NOT changed in this PR)
While verifying coverage we noticed two long-standing behaviors. Both **predate this change** and are left untouched to keep the PR focused; flagging for awareness:
1. **`/nsfw` sends its denial twice in private chats** — `COMMANDS/nsfw_cmd.py:46` and `:53` both call `is_user_in_channel()` in one pass. Today this already sends two subscribe-prompts to an unsubscribed user; the whitelist inherits the same double-send on that one path (elsewhere it is a single message). A one-line fix — reuse the value captured at `:46` — would resolve both. Happy to include here or as a separate PR.
2. **The document handler accepts files from anyone** — `COMMANDS/cookies_cmd.py:852`, `@app.on_message(filters.document)` with no access gate. Not a download path, but an outsider could still upload a `.txt` cookie file. A one-line `is_user_allowed(message)` guard would close it; left as a follow-up since documents were out of scope.

## Prior art in the fork network
For completeness: `obakha/StudentBot` (a fork of `upekshaip/tg-ytdlp-bot`) already attempted a similar "friends only" whitelist, but the private-chat side is **incomplete**:
- It adds a runtime `/auth` command backed by `CONFIG/auth.json`, plus `is_authorized_user` / `is_authorized_group` helpers.
- **Groups** are gated (`is_authorized_group` wired into `magic.py`'s `_is_allowed_group`).
- **Private chats are not actually restricted:** `is_authorized_user` is *defined but never called* — the DM gate was never wired in. Its README claims "only the configured user ID can interact", which the code does not back up (an outsider subscribed to the channel still gets full access). Callback buttons are ungated too.

This PR deliberately avoids that failure mode: `is_user_allowed` has two live call sites and DM coverage was checked across every private entry point (no dead predicate).

**Type of Change:** New feature

## Test plan
- ✅ Syntax — `python -m compileall` of every changed module: clean.
- ✅ Predicate logic (isolated) — empty→allow, friend→allow, stranger→deny + exactly one message, admin→allow, non-private→allow.
- ✅ Localization — `ACCESS_DENIED_PRIVATE_MSG` present exactly once in all 25 language files (strict `__getattr__` with no EN fallback, so a `[ACCESS_DENIED_PRIVATE_MSG]` placeholder is impossible).
- ⬜ Live smoke (maintainer/self) — `ALLOWED_USERS=[]` behaves as before; `ALLOWED_USERS=[<id>]` → listed user downloads in DM, outsider denied with one message, admin unaffected, groups unchanged.

## Backward compatibility
Default (empty list) preserves current behavior exactly; no migration. Documented via a comment in `CONFIG/_config.py` and both READMEs.

## Checklist
- ✅ Follows existing code style (mirrors `is_user_blocked` / `is_user_in_channel`)
- ✅ Self-review completed
- ✅ Config + README documentation updated
- ✅ No breaking changes
- ✅ One focused feature

## Notes for the maintainer
- If you'd rather have an issue to reference, I can open a Feature Request first (per `CONTRIBUTING.md`) and add `Fixes #N`; otherwise `## Motivation` stands in for it.
- Branch name `feat/allowed-users` matches the repo's real convention (`feat/hdr-quality-menu`).
- Complements the companion PR *"make channel subscription optional when SUBSCRIBE_CHANNEL is unset"*.
