### PR TITLE
feat: make channel subscription optional when SUBSCRIBE_CHANNEL is unset

### DIFF
--- a/CONFIG/_config.py
+++ b/CONFIG/_config.py
@@ -38,7 +38,7 @@ class Config(object):
     LOGS_IMG_ID = -100111111111111  # Channel ID for media command logs /img 
     LOGS_PAID_ID = -100111111111111  # Channel ID for paid media logs
     LOG_EXCEPTION = -100111111111111  # Channel ID for exception logs
-    # Channel ID to subscribe to
+    # Channel ID to subscribe to (optional: set to 0 or leave empty to disable the subscription requirement)
     SUBSCRIBE_CHANNEL = -100222222222222222222
     # Add subscription channel - Required (str)
     SUBSCRIBE_CHANNEL_URL = "https://t.me/+abcdef"

--- a/HELPERS/limitter.py
+++ b/HELPERS/limitter.py
@@ -142,6 +142,10 @@ def is_user_in_channel(app, message):
             return True
     except Exception:
         pass
+    # Subscription is optional: skip the check when SUBSCRIBE_CHANNEL is not configured
+    # (empty/0 = no channel gate; mirrors the ALLOWED_GROUP empty-list convention)
+    if not getattr(Config, 'SUBSCRIBE_CHANNEL', None):
+        return True
     try:
         logger.info(LoggerMsg.LIMITTER_CHANNEL_CHECK_MEMBERSHIP_LOG_MSG.format(
             user_id=message.chat.id, channel=Config.SUBSCRIBE_CHANNEL))

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Then edit `CONFIG/config.py` and fill in at least:
 - **API_ID**, **API_HASH** – from [my.telegram.org](https://my.telegram.org) (see section [Getting API Credentials](#getting-api-credentials))
 - **BOT_TOKEN** – from [@BotFather](https://t.me/BotFather) (see section [Getting API Credentials](#getting-api-credentials))
 - **LOGS\_*** (LOGS_ID, LOGS_VIDEO_ID, LOGS_NSFW_ID, LOGS_IMG_ID, LOGS_PAID_ID, LOG_EXCEPTION) – Fill in all the fields, if you want you can use the same channel for all
-- **SUBSCRIBE_CHANNEL** and **SUBSCRIBE_CHANNEL_URL** – channel ID and invite link users must join
+- **SUBSCRIBE_CHANNEL** and **SUBSCRIBE_CHANNEL_URL** – channel ID and invite link users must join (optional: set `SUBSCRIBE_CHANNEL` to `0` or leave empty to disable the subscription requirement)
 
 **Configuration Example:**
 

--- a/README_RU.md
+++ b/README_RU.md
@@ -256,7 +256,7 @@ cp CONFIG/_config.py CONFIG/config.py
 - **API_ID**, **API_HASH** – из [my.telegram.org](https://my.telegram.org)
 - **BOT_TOKEN** – из [@BotFather](https://t.me/BotFather)
 - **LOGS_*** – все лог-каналы
-- **SUBSCRIBE_CHANNEL** и **SUBSCRIBE_CHANNEL_URL** – канал подписки
+- **SUBSCRIBE_CHANNEL** и **SUBSCRIBE_CHANNEL_URL** – канал подписки (опционально: `0` или пусто в `SUBSCRIBE_CHANNEL` отключает требование подписки)
 
 **Пример конфигурации:**
 


### PR DESCRIPTION
## Summary
- **`HELPERS/limitter.py`** — in `is_user_in_channel()`, right after the group bypass, add `if not getattr(Config, 'SUBSCRIBE_CHANNEL', None): return True` — skip the subscription check entirely when no channel is configured.
- **`CONFIG/_config.py`** — clarify in the comment that empty/`0` disables the requirement.
- **`README.md` / `README_RU.md`** — document that `SUBSCRIBE_CHANNEL` is optional.

## Motivation
When `SUBSCRIBE_CHANNEL` is not configured (empty / `0`), `is_user_in_channel()` still calls `get_chat_member(0, ...)`, which fails and sends a **broken/empty** subscribe prompt — so every non-admin is locked out of a self-hosted instance that simply has no subscription channel. Complements the *"add ALLOWED_USERS private-chat whitelist"* PR: together they let a friends-only instance run purely on the whitelist, with no subscription channel.

## Behavior
- **`SUBSCRIBE_CHANNEL` empty/`0`:** subscription not required, no broken prompt — access is then governed by `ADMIN` / `ALLOWED_USERS` (or fully public if the whitelist is empty).
- **`SUBSCRIBE_CHANNEL` = real id:** subscription enforced exactly as before (the guard is falsy-gated, so it no-ops).

## Design notes / out of scope
- Mirrors the project's existing "empty ⇒ disabled" convention (same idiom as `ALLOWED_USERS` empty-list, and the anti-bot / channel-guard modules).
- The guard sits **after** the group bypass and (when combined with the whitelist PR) **after** the `is_user_allowed` check, so ordering stays: group bypass → whitelist → optional-subscription → membership check. It returns `True` silently (no message, no log) because `is_user_in_channel` runs on every message — a per-call log would be noise.
- `if not value` covers `int 0`, `None`, `""`, and a missing key. A stringified `"0"` would be truthy; the config default and typical value is the integer `0`, so this matches real usage.

**Type of Change:** New feature, documentation update

## Test plan
- ✅ Syntax — `python -m compileall HELPERS/limitter.py` clean.
- ⬜ `SUBSCRIBE_CHANNEL = 0` → no subscription required, no broken prompt.
- ⬜ `SUBSCRIBE_CHANNEL = <real id>` → subscription enforced as before.
- ⬜ `ALLOWED_USERS = [<id>]` + `SUBSCRIBE_CHANNEL = 0` → only whitelisted users pass, no channel needed.

## Backward compatibility
A configured `SUBSCRIBE_CHANNEL` behaves exactly as before (guard no-ops on a truthy value). Only the unconfigured case changes — and there the previous behaviour was a broken prompt, so this is strictly an improvement. No migration.

## Checklist
- ✅ Follows existing code style (empty ⇒ disabled idiom)
- ✅ Self-review completed
- ✅ README (EN + RU) updated
- ✅ No breaking changes
- ✅ One focused feature

## Notes for the maintainer
This is the single membership gate (`is_user_in_channel`) that all command handlers and `url_distractor` funnel through, so one guard covers every private entry point. Complements the companion PR *"add ALLOWED_USERS private-chat whitelist"*.
