### PR TITLE
fix(#323): skip gallery-dl fallback for URLs with no extractor

### DIFF
--- a/DOWN_AND_UP/gallery_dl_hook.py
+++ b/DOWN_AND_UP/gallery_dl_hook.py
@@ -820,6 +820,14 @@ def get_total_media_count(url: str, user_id=None, use_proxy: bool = False) -> in
                     return _get_total_media_count_fallback(url, user_id, use_proxy, cfg_path)
             else:
                 logger.warning(f"get_total_media_count failed: {result.stderr[:400]}")
+                # If gallery-dl reports "No suitable extractor" / "Unsupported",
+                # the URL is fundamentally unsupported — skip the --get-urls
+                # fallback which would just re-discover the same failure and add
+                # log noise (issue #323).
+                from HELPERS.fallback_helper import is_gallery_dl_no_extractor_error
+                if is_gallery_dl_no_extractor_error(result.stderr):
+                    logger.info(f"gallery-dl reports no extractor for {url}, skipping --get-urls fallback")
+                    return None
                 # Fallback to --get-urls for sites that don't work with --simulate
                 return _get_total_media_count_fallback(url, user_id, use_proxy, cfg_path)
         finally:
@@ -900,6 +908,13 @@ def _get_total_media_count_fallback(url: str, user_id, use_proxy: bool, cfg_path
             return len(lines)
         else:
             logger.warning(f"Fallback get_total_media_count failed: {result.stderr[:400]}")
+            # If gallery-dl reports "No suitable extractor", the URL is
+            # fundamentally unsupported — skip VK/Instagram/TikTok cookie
+            # retries which would all fail the same way (issue #323).
+            from HELPERS.fallback_helper import is_gallery_dl_no_extractor_error
+            if is_gallery_dl_no_extractor_error(result.stderr):
+                logger.info(f"gallery-dl reports no extractor for {url} (--get-urls), skipping further retries")
+                return None
             # For VK, always try without cookies if failed with cookies
             if is_vk_url:
                 logger.info("[VK] Failed with cookies, trying without cookies")

--- a/DOWN_AND_UP/yt_dlp_hook.py
+++ b/DOWN_AND_UP/yt_dlp_hook.py
@@ -11,7 +11,7 @@ from URL_PARSERS.filter_check import is_no_filter_domain
 from URL_PARSERS.filter_utils import create_smart_match_filter, create_legacy_match_filter
 from HELPERS.pot_helper import add_pot_to_ytdl_opts
 from CONFIG.limits import LimitsConfig
-from HELPERS.fallback_helper import should_fallback_to_gallery_dl
+from HELPERS.fallback_helper import should_fallback_to_gallery_dl, gallery_dl_has_extractor
 
 
 # Permanent, non-transient errors that cannot be fixed by retries, cookies,
@@ -385,10 +385,10 @@ def get_video_formats(url, user_id=None, playlist_start_index=1, cookies_already
             # Unsupported URL: only allow gallery-dl fallback (non-YouTube); otherwise bail out
             # without proxy/impersonate retries which cannot help unsupported domains (issue #323).
             if 'unsupported url' in _error_lower:
-                if should_fallback_to_gallery_dl(error_text, url):
+                if gallery_dl_has_extractor(url) and should_fallback_to_gallery_dl(error_text, url):
                     logger.info(f"Unsupported URL — deferring to gallery-dl fallback for {url}")
                     return {'error': 'FALLBACK_TO_GALLERY_DL', 'original_error': error_text}
-                logger.warning(f"Unsupported URL, no retries for {url}: {error_text[:200]}")
+                logger.warning(f"Unsupported URL (no yt-dlp or gallery-dl extractor), no retries for {url}: {error_text[:200]}")
                 return {'error': 'UNSUPPORTED_URL', 'original_error': error_text}
 
             # Check for YouTube cookie errors and try automatic retry

--- a/HELPERS/fallback_helper.py
+++ b/HELPERS/fallback_helper.py
@@ -128,5 +128,58 @@ def should_fallback_to_gallery_dl(error_message: str, url: str) -> bool:
     
     if is_tiktok and any(err in error_lower for err in ["429", "403", "401", "unable to download"]):
         return True
-    
+
     return False
+
+
+_GALLERY_DL_NO_EXTRACTOR_MARKERS = (
+    "no suitable extractor",
+    "unsupported url",
+    "no matching extractor",
+    "unsupported scheme",
+)
+
+
+def gallery_dl_has_extractor(url: str) -> bool:
+    """Return True when gallery-dl has a **specific** extractor for *url*.
+
+    A conservative check used to avoid expensive subprocess retry storms for
+    URLs that neither yt-dlp nor gallery-dl can handle (issue #323).
+
+    Returns True (don't block fallback) when:
+      * gallery-dl is not importable;
+      * the ``extractor.find`` API is unavailable;
+      * a specific (non-generic) extractor matches.
+
+    Returns False (skip fallback) only when ``find(url, default=None)``
+    explicitly returns *None*, meaning no extractor at all.
+    """
+    try:
+        import gallery_dl
+        find_fn = getattr(getattr(gallery_dl, "extractor", None), "find", None)
+        if find_fn is None:
+            return True
+        try:
+            result = find_fn(url, default=None)
+        except TypeError:
+            result = find_fn(url)
+        if result is None:
+            return False
+        name = result.__name__ if isinstance(result, type) else type(result).__name__
+        if name == "GenericExtractor":
+            return False
+        return True
+    except Exception:
+        return True
+
+
+def is_gallery_dl_no_extractor_error(stderr_text: str) -> bool:
+    """Check whether gallery-dl subprocess stderr indicates the URL has no
+    matching extractor at all (issue #323).
+
+    Used to short-circuit pointless ``--get-urls`` / cookie retries.
+    """
+    if not stderr_text:
+        return False
+    lower = stderr_text.lower()
+    return any(marker in lower for marker in _GALLERY_DL_NO_EXTRACTOR_MARKERS)


### PR DESCRIPTION
When yt-dlp reports 'Unsupported URL', the bot previously deferred to gallery-dl for every domain. For URLs that gallery-dl also cannot handle (epub.pub, beeg, third-party viewers, etc.), this caused 2+ subprocess calls (--simulate then --get-urls) each generating stderr warnings, plus a misleading 'Try gallery-dl' button that would fail again on click.

Changes:
- fallback_helper.py: add gallery_dl_has_extractor() (Python API check) and is_gallery_dl_no_extractor_error() (subprocess stderr check)
- yt_dlp_hook.py: before deferring to gallery-dl on 'Unsupported URL', verify gallery-dl actually has an extractor — if not, return clean UNSUPPORTED_URL instead of FALLBACK_TO_GALLERY_DL
- gallery_dl_hook.py: in get_total_media_count() and _get_total_media_count_fallback(), if gallery-dl subprocess stderr says 'no suitable extractor', skip the next fallback step (pointless retry)