### PR TITLE
fix: filter storyboard formats with abnormal tbr in disk space estimation

### DIFF
--- a/DOWN_AND_UP/down_and_up.py
+++ b/DOWN_AND_UP/down_and_up.py
@@ -876,10 +876,15 @@ def down_and_up(app, message, url, playlist_name, video_count, video_start_with,
                         size = int((float(tbr) * 1000.0 / 8.0) * float(duration))
                     else:
                         # последний шанс: взять максимальный tbr из форматов
+                        # НО фильтруем storyboard/dash форматы с аномальным tbr (>50 Mbps)
+                        # YouTube иногда отдаёт storyboard-форматы с tbr=137000+ Kbps,
+                        # что приводит к оценке в 70+ GiB для одного видео (issue #175)
                         formats = info_probe.get('formats') or []
                         best_tbr = 0
                         for f in formats:
                             ftbr = f.get('tbr') or 0
+                            if ftbr and ftbr > 50000:
+                                continue  # storyboard / dash segment — нереалистичный битрейт
                             if ftbr and ftbr > best_tbr:
                                 best_tbr = ftbr
                         if best_tbr and duration:


### PR DESCRIPTION
## Root Cause
YouTube returns storyboard/DASH segment formats (e.g. format 625) with `tbr=137655 Kbps` (137 Mbps).
When a video has no `filesize`/`filesize_approx`, the disk space estimation code took the **max tbr across ALL formats** → estimated **73.63 GiB** for a ~3 GiB video.

## Fix
Skip any format with `tbr > 50000 Kbps` (50 Mbps) in the fallback size estimation. Real video streams never exceed this; only storyboard/DASH segments have absurd bitrates.

## Affected
All 5 bots (DE, UAE, UK, IT, FR). Reported by user — even 144p said 'Not enough disk space'.

## Deployment
✅ Deployed to all 5 bots.