### PR TITLE
fix: issue triage August 2026 — ChannelGuard, format fallback, verbose logging, YouTube UX

### DIFF
--- a/COMMANDS/args_cmd.py
+++ b/COMMANDS/args_cmd.py
@@ -1939,14 +1939,41 @@ def get_user_ytdlp_args(user_id: int, url: str = None) -> Dict[str, Any]:
 
 def log_ytdlp_options(user_id: int, ytdlp_opts: dict, operation: str = "download"):
     messages = get_messages_instance(user_id)
-    """Log the final yt-dlp options for debugging"""
+    """Log the final yt-dlp options for debugging.
+
+    Only logs when Config.VERBOSE_LOGGING is True (issue #57).
+    Sensitive data is always redacted:
+    - cookiefile → '[SET]' or '[NOT_SET]'
+    - proxy URL → scheme://host:port (credentials stripped)
+    """
     try:
+        verbose = getattr(Config, 'VERBOSE_LOGGING', False)
+        if not verbose:
+            return
+
         # Create a copy to avoid modifying the original
         opts_copy = ytdlp_opts.copy()
-        
-        # Remove sensitive information
+
+        # Redact sensitive information
         if 'cookiefile' in opts_copy:
-            opts_copy['cookiefile'] = '[REDACTED]'
+            cookie_path = opts_copy['cookiefile']
+            opts_copy['cookiefile'] = '[SET: cookie.txt present]' if cookie_path else '[NOT_SET]'
+
+        # Redact proxy credentials — keep host:port for debugging
+        if 'proxy' in opts_copy and opts_copy['proxy']:
+            proxy_val = str(opts_copy['proxy'])
+            try:
+                from urllib.parse import urlparse
+                parsed = urlparse(proxy_val)
+                if parsed.hostname:
+                    redacted = f"{parsed.scheme or 'proxy'}://{parsed.hostname}"
+                    if parsed.port:
+                        redacted += f":{parsed.port}"
+                    opts_copy['proxy'] = redacted
+                else:
+                    opts_copy['proxy'] = '[REDACTED]'
+            except Exception:
+                opts_copy['proxy'] = '[REDACTED]'
         
         # Recursive sanitization for JSON: functions/objects -> string
         def _sanitize(value):

--- a/CONFIG/_config.py
+++ b/CONFIG/_config.py
@@ -247,3 +247,7 @@ class Config(object):
     DASHBOARD_PASSWORD = "admin123"
     ACTIVE_SESSIONS_FILE = "CONFIG/.active_sessions.json"
     #######################################################
+    # Verbose logging for yt-dlp options (issue #57)
+    # When True, logs ytdl_opts (format string, cookie presence, proxy host)
+    # at INFO level for every download operation. Sensitive data is redacted.
+    VERBOSE_LOGGING = False

--- a/CONFIG/errors.py
+++ b/CONFIG/errors.py
@@ -182,6 +182,18 @@ def classify_yt_dlp_error(error_message, url=None):
     ):
         return "AGE_RESTRICTED"
 
+    # YouTube bot-detection / sign-in required (issue #440)
+    # YouTube shows "Sign in to confirm you're not a bot" when it detects
+    # automated access. The bot already has cookie retry logic, but when all
+    # cookies fail the user should see a clear actionable message instead of
+    # a generic "extractor failed" error.
+    if (
+        "sign in to confirm" in error_lower
+        or "not a bot" in error_lower
+        or "sign in to confirm you" in error_lower
+    ):
+        return "SIGN_IN_REQUIRED"
+
     # Upstream server error (issue #356) — transient, show "try again later"
     if "http error 500" in error_lower or "internal server error" in error_lower:
         return "HTTP_500"

--- a/DOWN_AND_UP/always_ask_menu.py
+++ b/DOWN_AND_UP/always_ask_menu.py
@@ -7345,6 +7345,15 @@ def ask_quality_menu(app, message, url, tags, playlist_start_index=1, cb=None, d
             error_text = safe_get_messages(user_id).ALWAYS_ASK_EXTRACTOR_ERROR_MSG
         elif _err_category == "EMPTY_DOWNLOAD":
             error_text = safe_get_messages(user_id).ALWAYS_ASK_EMPTY_DOWNLOAD_MSG
+        elif _err_category == "SIGN_IN_REQUIRED":
+            # YouTube bot-detection: cookies didn't help or are missing.
+            # Show a specific, actionable message instead of the generic parse error.
+            error_text = (
+                "❌ <b>YouTube requires authentication</b>\n\n"
+                "<blockquote>Sign in to confirm you're not a bot</blockquote>\n"
+                f"\n<code>{sanitized_error}</code>\n\n"
+                "🔑 <b>Use the <code>/cookie</code> command to add cookies and try again.</b>\n"
+            )
         
         # Try to edit the processing message to show error first
         try:

--- a/DOWN_AND_UP/down_and_up.py
+++ b/DOWN_AND_UP/down_and_up.py
@@ -391,6 +391,7 @@ def down_and_up(app, message, url, playlist_name, video_count, video_start_with,
     did_proxy_retry = False
     did_cookie_retry = False
     did_live_from_start_retry = False
+    did_format_fallback = False
     is_hls = False
     error_message_sent = False  # Flag to prevent duplicate error messages
     
@@ -1351,7 +1352,7 @@ def down_and_up(app, message, url, playlist_name, video_count, video_start_with,
 
         def try_download(url, attempt_opts):
             messages = safe_get_messages(message.chat.id)
-            nonlocal current_total_process, error_message, did_cookie_retry, did_proxy_retry, did_live_from_start_retry, is_hls, error_message_sent, is_reverse_order, use_range_download, current_playlist_items_override, range_entries_metadata, download_sections, hls_file_found, auto_range_added
+            nonlocal current_total_process, error_message, did_cookie_retry, did_proxy_retry, did_live_from_start_retry, did_format_fallback, is_hls, error_message_sent, is_reverse_order, use_range_download, current_playlist_items_override, range_entries_metadata, download_sections, hls_file_found, auto_range_added
             # Initialize hls_file_found for this download attempt
             hls_file_found = False
 
@@ -2516,7 +2517,21 @@ def down_and_up(app, message, url, playlist_name, video_count, video_start_with,
                 
                 # Check for format not available error
                 if "Requested format is not available" in error_message:
-                    logger.error(f"Format not available error: {error_message}")
+                    if not did_format_fallback:
+                        logger.warning(f"Format not available, retrying with format='best': {error_message}")
+                        did_format_fallback = True
+                        fallback_opts = attempt_opts.copy()
+                        fallback_opts['format'] = 'best'
+                        # Remove YouTube-specific extractor args that may constrain formats
+                        if 'extractor_args' in fallback_opts and 'youtube' in fallback_opts['extractor_args']:
+                            del fallback_opts['extractor_args']['youtube']
+                        retry_result = try_download(url, fallback_opts)
+                        if retry_result is not None:
+                            logger.info(f"Format fallback to 'best' successful for user {user_id}")
+                            return retry_result
+                        else:
+                            logger.warning(f"Format fallback to 'best' also failed for user {user_id}")
+                    logger.error(f"Format not available error (after fallback): {error_message}")
                     return "FORMAT_NOT_AVAILABLE"
                 
                 # Check for rename errors (common with DASH downloads when .part file is missing)
@@ -3162,6 +3177,7 @@ def down_and_up(app, message, url, playlist_name, video_count, video_start_with,
             did_cookie_retry = False
             did_proxy_retry = False
             did_live_from_start_retry = False
+            did_format_fallback = False
             error_message_sent = False  # Reset error message flag for each playlist item
             network_error = False
 

--- a/HELPERS/anti_bot_protection.py
+++ b/HELPERS/anti_bot_protection.py
@@ -483,8 +483,33 @@ def _check_24h_activity(ud: _UserData, now: float) -> Optional[str]:
 
 # ── Channel ban (blocking — for admin commands & background bans) ────────
 
+def _run_async(coro, timeout=30):
+    """Run an async coroutine from a synchronous context (background thread).
+
+    Pyrogram Client methods are async under the hood.  When the main event loop
+    is already running (the normal case — ``app.start()`` was called), the
+    sync wrapper returns a bare coroutine instead of executing it.  This helper
+    schedules the coroutine on the running loop via
+    ``asyncio.run_coroutine_threadsafe`` and blocks until completion.
+    """
+    import asyncio
+    try:
+        loop = asyncio.get_event_loop()
+        if loop.is_running():
+            future = asyncio.run_coroutine_threadsafe(coro, loop)
+            return future.result(timeout=timeout)
+        else:
+            return asyncio.run(coro)
+    except RuntimeError:
+        return asyncio.run(coro)
+
+
 def ban_user_from_channel(user_id: int, reason: str = "manual"):
-    """Ban user from subscribe channel if bot is admin."""
+    """Ban user from subscribe channel if bot is admin.
+
+    Uses ``_run_async`` to properly execute Pyrogram async coroutines from
+    this synchronous function (which runs in a background thread).
+    """
     logger.info(f"[CHANNEL_BAN] Attempting to ban user {user_id} from channel, reason: {reason}")
 
     try:
@@ -502,7 +527,7 @@ def ban_user_from_channel(user_id: int, reason: str = "manual"):
 
         try:
             from pyrogram.enums import ChatMemberStatus
-            bot_member = app.get_chat_member(subscribe_channel, "me")
+            bot_member = _run_async(app.get_chat_member(subscribe_channel, "me"))
             logger.info(f"[CHANNEL_BAN] Bot status in channel: {bot_member.status}")
 
             if bot_member.status not in (ChatMemberStatus.ADMINISTRATOR, ChatMemberStatus.OWNER):
@@ -523,7 +548,7 @@ def ban_user_from_channel(user_id: int, reason: str = "manual"):
             logger.error(f"[CHANNEL_BAN] Failed to check bot permissions in channel: {check_error}")
 
         try:
-            user_member = app.get_chat_member(subscribe_channel, user_id)
+            user_member = _run_async(app.get_chat_member(subscribe_channel, user_id))
             logger.info(f"[CHANNEL_BAN] User {user_id} status in channel: {user_member.status}")
 
             if user_member.status == ChatMemberStatus.BANNED:
@@ -539,11 +564,11 @@ def ban_user_from_channel(user_id: int, reason: str = "manual"):
 
         try:
             logger.info(f"[CHANNEL_BAN] Calling ban_chat_member for user {user_id} in channel {subscribe_channel}")
-            result = app.ban_chat_member(
+            result = _run_async(app.ban_chat_member(
                 chat_id=subscribe_channel,
                 user_id=user_id,
                 until_date=0,
-            )
+            ))
             logger.info(f"[CHANNEL_BAN] Successfully banned user {user_id} from channel {subscribe_channel} due to: {reason}")
             logger.debug(f"[CHANNEL_BAN] ban_chat_member result: {result}")
         except Exception as e:


### PR DESCRIPTION
## Issue Triage — August 2026

### Fixes included

| Commit | Issue | Severity | Description |
|--------|-------|----------|-------------|
| `a9f90a2` | #441 | 🔴 CRITICAL | `ban_user_from_channel()` called async Pyrogram methods (`get_chat_member`, `ban_chat_member`) without await. Added `_run_async()` helper using `asyncio.run_coroutine_threadsafe()`. ChannelGuard was completely broken — bans never applied. |
| `664656a` | #440 | 🟠 HIGH | YouTube "Sign in to confirm you're not a bot" was shown as generic "extractor failed to parse page". Added `SIGN_IN_REQUIRED` category to `classify_yt_dlp_error()` with actionable message pointing to `/cookie` command. |
| `03ff85b` | #78  | 🟠 HIGH | "Requested format is not available" (80+ cases/24h) had no fallback. Now retries with `format='best'` automatically before returning error. |
| `661e245` | #57  | 🔵 enhancement | Added `VERBOSE_LOGGING` config flag. When True, logs ytdl_opts (format, cookie presence, proxy host without credentials) for debugging. Default: False. |

### Files changed (5)
- `HELPERS/anti_bot_protection.py` — async fix
- `CONFIG/errors.py` — new SIGN_IN_REQUIRED category
- `DOWN_AND_UP/always_ask_menu.py` — YouTube auth error UX
- `DOWN_AND_UP/down_and_up.py` — format fallback logic
- `COMMANDS/args_cmd.py` + `CONFIG/_config.py` — verbose logging

### Testing
- All files pass `python3 -m compileall` syntax check
- No sensitive data in diffs (verified)
