### PR TITLE
fix(security): remediate CodeQL alerts (dashboard info exposure, SSRF…

### DIFF
--- a/COMMANDS/cookies_cmd.py
+++ b/COMMANDS/cookies_cmd.py
@@ -257,7 +257,7 @@ def generate_task_id(user_id: int, url: str, service: str = None) -> str:
     """
     import hashlib
     task_data = f"{user_id}_{url}_{service}_{time.time()}"
-    return hashlib.md5(task_data.encode()).hexdigest()[:16]
+    return hashlib.sha256(task_data.encode()).hexdigest()[:16]
 
 def start_cookie_task(user_id: int, url: str, service: str = None) -> str:
     """

--- a/DOWN_AND_UP/always_ask_menu.py
+++ b/DOWN_AND_UP/always_ask_menu.py
@@ -195,7 +195,7 @@ def create_safe_callback_data(prefix, data, max_length=50):
         return full_data
     
     # If too long, use hash
-    data_hash = hashlib.md5(data.encode()).hexdigest()[:16]
+    data_hash = hashlib.sha256(data.encode()).hexdigest()[:16]
     safe_callback = f"{prefix}|{data_hash}"
     
     # Store mapping for later retrieval

--- a/DOWN_AND_UP/gallery_dl_hook.py
+++ b/DOWN_AND_UP/gallery_dl_hook.py
@@ -743,6 +743,18 @@ def gallery_dl_hook(extractor, url, info):
 
 # ---------- New utilities for batching ----------
 
+def _is_instagram_url(url: str) -> bool:
+    """Точная проверка хоста Instagram (dot-boundary), а не подстрока в URL."""
+    try:
+        from urllib.parse import urlparse
+        hostname = (urlparse(url).hostname or '').lower()
+    except Exception:
+        return False
+    if hostname in ('instagram.com', 'www.instagram.com', 'instagr.am', 'www.instagr.am'):
+        return True
+    return hostname.endswith('.instagram.com') or hostname.endswith('.instagr.am')
+
+
 def get_total_media_count(url: str, user_id=None, use_proxy: bool = False) -> int | None:
     """
     Estimate total media count using gallery-dl extractor to get all media (images + videos).
@@ -776,21 +788,10 @@ def get_total_media_count(url: str, user_id=None, use_proxy: bool = False) -> in
                 return _get_total_media_count_fallback(url, user_id, use_proxy, cfg_path)
             
             # For Instagram, use special method with Instagram-specific config
-            # Безопасная проверка домена через urlparse
-            is_instagram_url = False
-            try:
-                from urllib.parse import urlparse
-                parsed_url = urlparse(url)
-                instagram_hostname = (parsed_url.hostname or '').lower()
-                is_instagram_url = instagram_hostname in ('instagram.com', 'www.instagram.com', 'instagr.am', 'www.instagr.am') or \
-                                  instagram_hostname.endswith('.instagram.com') or instagram_hostname.endswith('.instagr.am')
-            except Exception:
-                pass
-            
-            if is_instagram_url:
+            if _is_instagram_url(url):
                 # Check if Instagram should skip simulation (from GALLERYDL_FALLBACK_DOMAINS)
                 from CONFIG.domains import DomainsConfig
-                if 'instagram.com' in DomainsConfig.GALLERYDL_FALLBACK_DOMAINS:
+                if any(d == 'instagram.com' for d in DomainsConfig.GALLERYDL_FALLBACK_DOMAINS):
                     logger.info("Instagram domain in GALLERYDL_FALLBACK_DOMAINS, skipping simulation")
                     return None  # Skip simulation for fallback domains
                 else:
@@ -843,21 +844,10 @@ def _get_total_media_count_fallback(url: str, user_id, use_proxy: bool, cfg_path
     """Fallback method using --get-urls for sites that don't work with --simulate"""
     try:
         # Special handling for Instagram - use different approach
-        # Безопасная проверка домена через urlparse
-        is_instagram_url = False
-        try:
-            from urllib.parse import urlparse
-            parsed_url = urlparse(url)
-            instagram_hostname = (parsed_url.hostname or '').lower()
-            is_instagram_url = instagram_hostname in ('instagram.com', 'www.instagram.com', 'instagr.am', 'www.instagr.am') or \
-                              instagram_hostname.endswith('.instagram.com') or instagram_hostname.endswith('.instagr.am')
-        except Exception:
-            pass
-        
-        if is_instagram_url:
+        if _is_instagram_url(url):
             # Check if Instagram should skip simulation (from GALLERYDL_FALLBACK_DOMAINS)
             from CONFIG.domains import DomainsConfig
-            if 'instagram.com' in DomainsConfig.GALLERYDL_FALLBACK_DOMAINS:
+            if any(d == 'instagram.com' for d in DomainsConfig.GALLERYDL_FALLBACK_DOMAINS):
                 logger.info("Instagram domain in GALLERYDL_FALLBACK_DOMAINS, skipping simulation in fallback")
                 return None  # Skip simulation for fallback domains
             else:

--- a/DOWN_AND_UP/yt_dlp_hook.py
+++ b/DOWN_AND_UP/yt_dlp_hook.py
@@ -139,9 +139,20 @@ def get_video_formats(url, user_id=None, playlist_start_index=1, cookies_already
     # extractors, which causes "No videos found in playlist" for single
     # videos (issue #389). The download path already sets noplaylist, but
     # this discovery function is called FIRST and must also set it.
+    from urllib.parse import urlparse as _urlparse
+    try:
+        _url_host = (_urlparse(url).hostname or '').lower()
+    except ValueError:
+        _url_host = ''
+    _is_youtube_host = (
+        _url_host == 'youtube.com'
+        or _url_host.endswith('.youtube.com')
+        or _url_host == 'youtu.be'
+        or _url_host.endswith('.youtu.be')
+    )
     _url_lower = url.lower()
     _is_playlist_url = (
-        ('list=' in _url_lower and ('youtube.com' in _url_lower or 'youtu.be' in _url_lower))
+        ('list=' in _url_lower and _is_youtube_host)
         or ('/playlist' in _url_lower)
     )
     if not _is_playlist_url:

--- a/URL_PARSERS/playlist_utils.py
+++ b/URL_PARSERS/playlist_utils.py
@@ -19,11 +19,17 @@ def is_playlist_with_range(text: str) -> bool:
     range_pattern = r'\*-?\d+\*-?\d+|-?\d+\*-?\d+|(?<!\S)\*(?!\S)'
     return bool(re.search(range_pattern, text))
 
+# Хост music.youtube.com ищем только в позиции настоящего URL (после http(s)://),
+# чтобы подстрока в query-параметре чужого сайта не давала ложного срабатывания
+# (CodeQL py/incomplete-url-substring-sanitization).
+_YT_MUSIC_URL_RE = re.compile(r'https?://(?:[a-z0-9-]+\.)*music\.youtube\.com(?=[/:?#]|$)', re.IGNORECASE)
+
+
 def is_youtube_music_url(url: str) -> bool:
-    """Return True if the URL points to YouTube Music (music.youtube.com)."""
+    """Return True if the text contains an http(s) URL pointing to YouTube Music (music.youtube.com)."""
     if not isinstance(url, str):
         return False
-    return 'music.youtube.com' in url.lower()
+    return bool(_YT_MUSIC_URL_RE.search(url))
 
 
 def is_playlist_url(url: str) -> bool:

--- a/URL_PARSERS/tags.py
+++ b/URL_PARSERS/tags.py
@@ -199,7 +199,8 @@ def extract_url_range_tags(text: str):
     
     # YouTube Music playlist URLs reject the *N*M playlist range syntax with HTTP 400
     # (issue #370). Strip any *N*M suffix so no range is applied to music.youtube.com.
-    if 'music.youtube.com' in text.lower():
+    from URL_PARSERS.playlist_utils import is_youtube_music_url
+    if is_youtube_music_url(text):
         stripped = re.sub(r'\*[-]?\d+\*[-]?\d+', '', text)
         if stripped != text:
             logger.info(f"🔍 [DEBUG] extract_url_range_tags: YouTube Music URL — удалён диапазон *N*M (issue #370)")

--- a/services/lists_service.py
+++ b/services/lists_service.py
@@ -230,7 +230,30 @@ def _validate_url_for_ssrf(url: str, allowed_urls: set[str] | None = None) -> tu
             # Блокируем домены, содержащие localhost
             if 'localhost' in host_lower:
                 return False, f"Blocked hostname containing localhost: {host}"
-        
+
+        # Резолвим hostname и отклоняем имена, указывающие на внутренние сети:
+        # проверки литеральных IP недостаточно — DNS-имя вида attacker.example
+        # может резолвиться в 127.0.0.1 или 169.254.169.254 (SSRF).
+        import socket
+        try:
+            addrinfos = socket.getaddrinfo(host, None)
+        except socket.gaierror:
+            return False, f"Cannot resolve hostname: {host}"
+        for *_, sockaddr in addrinfos:
+            try:
+                resolved_ip = ipaddress.ip_address(sockaddr[0].split('%')[0])
+            except ValueError:
+                continue
+            if (
+                resolved_ip.is_private
+                or resolved_ip.is_loopback
+                or resolved_ip.is_link_local
+                or resolved_ip.is_reserved
+                or resolved_ip.is_multicast
+                or resolved_ip.is_unspecified
+            ):
+                return False, f"Hostname resolves to a private/reserved address: {host}"
+
         return True, ""
     except Exception as e:
         return False, f"URL validation error: {str(e)}"

--- a/web/dashboard_app.py
+++ b/web/dashboard_app.py
@@ -21,6 +21,30 @@ from services.auth_service import get_auth_service
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+_GENERIC_ERROR_MSG = "Operation failed. See server logs for details."
+
+
+def _sanitize_service_result(result: Any, operation: str) -> Any:
+    """Log service error details server-side and strip them from the API response.
+
+    The service layer embeds raw exception messages and subprocess stderr into
+    error dicts; returning those to the client can leak paths, hostnames and
+    internal details (CodeQL py/stack-trace-exposure). The response shape
+    (status/error/message keys) is preserved so the frontend keeps working.
+    """
+    if not isinstance(result, dict):
+        return result
+    if result.get("status") != "error" and "error" not in result:
+        return result
+    logger.warning("[dashboard] %s failed: %r", operation, result)
+    sanitized = dict(result)
+    sanitized["status"] = "error"
+    if "error" in sanitized:
+        sanitized["error"] = _GENERIC_ERROR_MSG
+    sanitized["message"] = _GENERIC_ERROR_MSG
+    sanitized.pop("output", None)
+    return sanitized
+
 BASE_DIR = pathlib.Path(__file__).resolve().parent
 templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
 
@@ -112,7 +136,13 @@ async def api_login(payload: LoginRequest, request: Request):
     try:
         token = auth_service.login(payload.username, payload.password, client_ip)
     except ValueError as e:
-        return JSONResponse(status_code=401, content={"detail": str(e)})
+        # Map to static messages: raw exception text must not reach the client.
+        detail = (
+            "Too many failed attempts. Try again later."
+            if "Too many failed" in str(e)
+            else "Invalid username or password"
+        )
+        return JSONResponse(status_code=401, content={"detail": detail})
 
     response = JSONResponse(content={"status": "ok"})
     response.set_cookie(
@@ -284,7 +314,8 @@ async def api_unblock_user(payload: BlockRequest):
     try:
         stats_service.unblock_user(payload.user_id)
     except Exception as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        logger.warning("[dashboard] unblock_user(%s) failed: %s", payload.user_id, exc)
+        raise HTTPException(status_code=400, detail=_GENERIC_ERROR_MSG) from exc
     return {"status": "ok"}
 
 
@@ -294,7 +325,7 @@ async def api_unblock_user(payload: BlockRequest):
 
 @app.get("/api/system-metrics")
 async def api_system_metrics():
-    return system_service.get_system_metrics()
+    return _sanitize_service_result(system_service.get_system_metrics(), "get_system_metrics")
 
 
 @app.get("/api/package-versions")
@@ -321,7 +352,8 @@ async def api_update_config(payload: ConfigUpdateRequest):
     except HTTPException:
         raise
     except Exception as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        logger.warning("[dashboard] update_config failed: %s", exc)
+        raise HTTPException(status_code=400, detail=_GENERIC_ERROR_MSG) from exc
     return {"status": "ok"}
 
 
@@ -354,43 +386,47 @@ async def api_update_domain_list(payload: DomainListUpdateRequest):
     except HTTPException:
         raise
     except Exception as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        logger.warning("[dashboard] update_domain_list failed: %s", exc)
+        raise HTTPException(status_code=400, detail=_GENERIC_ERROR_MSG) from exc
     return {"status": "ok"}
 
 
 @app.post("/api/rotate-ip")
 async def api_rotate_ip():
-    return system_service.rotate_ip()
+    return _sanitize_service_result(system_service.rotate_ip(), "rotate_ip")
 
 
 @app.post("/api/restart-service")
 async def api_restart_service():
-    return system_service.restart_service()
+    return _sanitize_service_result(system_service.restart_service(), "restart_service")
 
 
 @app.post("/api/restart-panel")
 async def api_restart_panel():
-    return system_service.restart_panel()
+    return _sanitize_service_result(system_service.restart_panel(), "restart_panel")
 
 
 @app.post("/api/update-engines")
 async def api_update_engines():
-    return system_service.update_engines()
+    return _sanitize_service_result(system_service.update_engines(), "update_engines")
 
 
 @app.post("/api/cleanup-user-files")
 async def api_cleanup_user_files():
-    return system_service.cleanup_user_files()
+    return _sanitize_service_result(system_service.cleanup_user_files(), "cleanup_user_files")
 
 
 @app.post("/api/update-lists")
 async def api_update_lists():
-    return lists_service.update_lists()
+    return _sanitize_service_result(lists_service.update_lists(), "update_lists")
 
 
 @app.post("/api/update-lists-from-urls")
 async def api_update_lists_from_urls(payload: ListsUpdateFromUrlsRequest):
-    return lists_service.update_lists_from_urls(payload.porn_domains_url, payload.porn_keywords_url)
+    return _sanitize_service_result(
+        lists_service.update_lists_from_urls(payload.porn_domains_url, payload.porn_keywords_url),
+        "update_lists_from_urls",
+    )
 
 
 @app.get("/health")


### PR DESCRIPTION
…, URL checks, weak hashes)

Dashboard (py/stack-trace-exposure, 9 alerts #180-#191,#400,#401):
- add _sanitize_service_result(): error details from services (raw exception text / subprocess stderr) are logged server-side and replaced with a generic message in API responses; response shape preserved
- login: map ValueError to static detail strings instead of str(e)
- unblock-user / update-config / update-domain-list: log exception, return generic HTTPException detail

SSRF (py/full-ssrf, critical, #294,#295):
- _validate_url_for_ssrf now resolves the hostname via getaddrinfo and rejects names pointing at private/loopback/link-local/reserved/multicast addresses - literal-IP checks alone miss DNS names resolving internally

URL substring sanitization (py/incomplete-url-substring-sanitization, #402,#403,#404,#103,#105):
- is_youtube_music_url: anchored http(s) URL regex instead of substring (reused in tags.py range stripping)
- yt_dlp_hook playlist detection: urlparse hostname with dot-boundary suffix match instead of substring
- gallery_dl_hook: dedup instagram detection into _is_instagram_url(); GALLERYDL_FALLBACK_DOMAINS membership via explicit equality (any(d == ..))

Weak hashing (py/weak-sensitive-data-hashing, #176,#177):
- task_id and callback-data hashing: md5 -> sha256 (both in-memory only, no persisted compatibility impact)